### PR TITLE
Extend play metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "4",
+    "jsnetworkx": "fkling/JSNetworkX#v0.3.4",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -33,13 +33,19 @@ class PlayMetrics extends Component {
     this.setState({
       density,
       diameter,
-      averagePathLength: sum / numPairs
+      averagePathLength: sum / numPairs,
+      averageClustering: jsnx.averageClustering(G)
     });
   }
 
   render () {
     const {data, graph} = this.props;
-    const {density, diameter, averagePathLength} = this.state;
+    const {
+      density,
+      diameter,
+      averagePathLength,
+      averageClustering
+    } = this.state;
 
     const csvUrl = `/api/corpus/${data.corpus}/play/${data.id}/networkdata/csv`;
 
@@ -61,6 +67,8 @@ class PlayMetrics extends Component {
         Diameter: {diameter}
         <br/>
         Average path length: {round(averagePathLength)}
+        <br/>
+        Average clustering coefficient: {round(averageClustering)}
         <br/>
         <a href={csvUrl} download={`${data.id}.csv`}>
           Download CSV

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -25,6 +25,8 @@ class PlayMetrics extends Component {
         All-in at segment {data.allInSegment + ' '}
         (at {allInPercentage}%)
         <br/>
+        <span title="number of characters">Network size</span>: {numNodes}
+        <br/>
         Density: {density}
         <br/>
         <a href={csvUrl} download={`${data.id}.csv`}>

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -30,9 +30,27 @@ class PlayMetrics extends Component {
         }
       }
     }
+
+    let maxDegree = 0;
+    let maxDegreeIds = [];
+    const degrees = jsnx.degree(G);
+    for (const d of degrees) {
+      const id = d[0];
+      const degree = d[1];
+      if (degree === maxDegree) {
+        maxDegreeIds.push(id);
+      } else if (degree > maxDegree) {
+        maxDegree = degree;
+        maxDegreeIds = [];
+        maxDegreeIds.push(id);
+      }
+    }
+
     this.setState({
       density,
       diameter,
+      maxDegree,
+      maxDegreeIds,
       averagePathLength: sum / numPairs,
       averageClustering: jsnx.averageClustering(G)
     });
@@ -43,6 +61,8 @@ class PlayMetrics extends Component {
     const {
       density,
       diameter,
+      maxDegree,
+      maxDegreeIds,
       averagePathLength,
       averageClustering
     } = this.state;
@@ -69,6 +89,8 @@ class PlayMetrics extends Component {
         Average path length: {round(averagePathLength)}
         <br/>
         Average clustering coefficient: {round(averageClustering)}
+        <br/>
+        Maximum degree: {maxDegree} (<em>{maxDegreeIds.join(', ')}</em>)
         <br/>
         <a href={csvUrl} download={`${data.id}.csv`}>
           Download CSV

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -31,12 +31,14 @@ class PlayMetrics extends Component {
       }
     }
 
+    let sumDegrees = 0;
     let maxDegree = 0;
     let maxDegreeIds = [];
     const degrees = jsnx.degree(G);
     for (const d of degrees) {
       const id = d[0];
       const degree = d[1];
+      sumDegrees += degree;
       if (degree === maxDegree) {
         maxDegreeIds.push(id);
       } else if (degree > maxDegree) {
@@ -51,6 +53,7 @@ class PlayMetrics extends Component {
       diameter,
       maxDegree,
       maxDegreeIds,
+      averageDegree: sumDegrees / graph.nodes.length,
       averagePathLength: sum / numPairs,
       averageClustering: jsnx.averageClustering(G)
     });
@@ -63,6 +66,7 @@ class PlayMetrics extends Component {
       diameter,
       maxDegree,
       maxDegreeIds,
+      averageDegree,
       averagePathLength,
       averageClustering
     } = this.state;
@@ -89,6 +93,8 @@ class PlayMetrics extends Component {
         Average path length: {round(averagePathLength)}
         <br/>
         Average clustering coefficient: {round(averageClustering)}
+        <br/>
+        Average degree: {round(averageDegree)}
         <br/>
         Maximum degree: {maxDegree} (<em>{maxDegreeIds.join(', ')}</em>)
         <br/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,6 +929,12 @@ babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+babel-runtime@^5:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  dependencies:
+    core-js "^1.0.0"
+
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
@@ -4174,6 +4180,15 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+jsnetworkx@fkling/JSNetworkX#v0.3.4:
+  version "0.3.4"
+  resolved "https://codeload.github.com/fkling/JSNetworkX/tar.gz/25d535abce672253fd35117d730f65157c23241f"
+  dependencies:
+    babel-runtime "^5"
+    lodash "^3.3.1"
+    through "^2.3.6"
+    tiny-sprintf "^0.3.0"
+
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
@@ -4428,6 +4443,10 @@ lodash.upperfirst@^4.2.0:
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^3.3.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 log-symbols@^2.0.0:
   version "2.1.0"
@@ -6755,6 +6774,10 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-sprintf@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tiny-sprintf/-/tiny-sprintf-0.3.0.tgz#4272fd5c1d2f92807223fc16d728fdf30595a33e"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
This introduces [JSnetworkX](http://jsnetworkx.org), which we use to calculate more network metrics per play (issue #9).