### PR TITLE
Reorganise Speech distribution tab

### DIFF
--- a/src/components/SpeechDistribution.js
+++ b/src/components/SpeechDistribution.js
@@ -1,41 +1,50 @@
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import {Form, FormGroup, Label, Input} from 'reactstrap';
 import Sapogov from './SpeechDistribution/Sapogov';
 import Yarkho from './SpeechDistribution/Yarkho';
 
-class SpeechDistribution extends Component {
-  render () {
-    const {groups, segments} = this.props;
+const SpeechDistribution = ({groups, segments}) => {
+  const [chartType, setChartType] = useState('sapogov');
 
-    return (
-      <div style={{width: '100%'}}>
-        <div className="speech-dist-container d-flex">
-          <div style={{position: 'relative', width: '90%'}}>
-            <Sapogov {...{groups, segments}}/>
-          </div>
-          <div style={{position: 'relative', width: '90%'}}>
-            <Yarkho {...{groups, segments}}/>
-          </div>
-        </div>
-        <br/>
-        <p>
-          {'Cf. '}
-          <a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">
-            Sapogov 1974
-          </a>
-          {', '}
-          <a href="http://rvb.ru/philologica/04/04iarxo.htm">
-            Yarkho 1997 (ru)
-          </a>
-          {', '}
-          <a href="https://doi.org/10.1515/jlt-2019-0002">
-            Yarkho 2019 (en)
-          </a>
-        </p>
-      </div>
-    );
+  let chart;
+  if (chartType === 'yarkho') {
+    chart = <Yarkho {...{groups, segments}}/>;
+  } else {
+    chart = <Sapogov {...{groups, segments}}/>;
   }
-}
+
+  const handleChange = e => setChartType(e.target.value);
+
+  return (
+    <div style={{width: '100%'}}>
+      <Form>
+        <FormGroup check inline>
+          <Label check>
+            <Input
+              type="radio"
+              value="sapogov"
+              checked={chartType === 'sapogov'}
+              onChange={handleChange}
+            /> Sapogov
+          </Label>
+        </FormGroup>
+        <FormGroup check inline>
+          <Label check>
+            <Input
+              type="radio"
+              value="yarkho"
+              checked={chartType === 'yarkho'}
+              onChange={handleChange}
+            /> Yarkho
+          </Label>
+        </FormGroup>
+      </Form>
+      <br/>
+      {chart}
+    </div>
+  );
+};
 
 SpeechDistribution.propTypes = {
   groups: PropTypes.array.isRequired,

--- a/src/components/SpeechDistribution/Sapogov.js
+++ b/src/components/SpeechDistribution/Sapogov.js
@@ -99,7 +99,17 @@ class Sapogov extends Component {
       options.scales.yAxes[0].ticks.stepSize = 1;
     }
 
-    return <Line data={data} options={options}/>;
+    return (
+      <>
+        <Line data={data} options={options}/>
+        <p>
+          {'Cf. '}
+          <a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">
+            Sapogov 1974
+          </a>
+        </p>
+      </>
+    );
   }
 }
 

--- a/src/components/SpeechDistribution/Yarkho.js
+++ b/src/components/SpeechDistribution/Yarkho.js
@@ -143,7 +143,21 @@ class Yarkho extends Component {
       options.scales.yAxes[0].ticks.stepSize = 1;
     }
 
-    return <Line data={data} options={options}/>;
+    return (
+      <>
+        <Line data={data} options={options}/>
+        <p>
+          {'Cf. '}
+          <a href="http://rvb.ru/philologica/04/04iarxo.htm">
+            Yarkho 1997 (ru)
+          </a>
+          {', '}
+          <a href="https://doi.org/10.1515/jlt-2019-0002">
+            Yarkho 2019 (en)
+          </a>
+        </p>
+      </>
+    );
   }
 }
 


### PR DESCRIPTION
This PR reorganises the speech distribution tab to only show one chart at a time. Switching between the different types of charts is implemented with radio button selection.

This is a solution for #67 and a prerequisite for #65.