### PR TITLE
Add Trilcke/Fischer beat chart to speech distribution tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-scripts": "3.0.1",
     "react-sigma": "^1.2.30",
     "reactstrap": "8.0.0",
+    "recharts": "^1.8.5",
     "swagger-ui-react": "^3.22.2",
     "yasgui": "^2.7.29"
   },

--- a/src/components/SpeechDistribution.js
+++ b/src/components/SpeechDistribution.js
@@ -3,13 +3,16 @@ import PropTypes from 'prop-types';
 import {Form, FormGroup, Label, Input} from 'reactstrap';
 import Sapogov from './SpeechDistribution/Sapogov';
 import Yarkho from './SpeechDistribution/Yarkho';
+import TrilckeFischer from './SpeechDistribution/TrilckeFischer';
 
 const SpeechDistribution = ({groups, segments}) => {
-  const [chartType, setChartType] = useState('sapogov');
+  const [chartType, setChartType] = useState('trilckefischer');
 
   let chart;
   if (chartType === 'yarkho') {
     chart = <Yarkho {...{groups, segments}}/>;
+  } else if (chartType === 'trilckefischer') {
+    chart = <TrilckeFischer {...{segments}}/>;
   } else {
     chart = <Sapogov {...{groups, segments}}/>;
   }
@@ -37,6 +40,16 @@ const SpeechDistribution = ({groups, segments}) => {
               checked={chartType === 'yarkho'}
               onChange={handleChange}
             /> Yarkho
+          </Label>
+        </FormGroup>
+        <FormGroup check inline>
+          <Label check>
+            <Input
+              type="radio"
+              value="trilckefischer"
+              checked={chartType === 'trilckefischer'}
+              onChange={handleChange}
+            /> Trilcke/Fischer et al.
           </Label>
         </FormGroup>
       </Form>

--- a/src/components/SpeechDistribution.js
+++ b/src/components/SpeechDistribution.js
@@ -1,41 +1,50 @@
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import {Form, FormGroup, Label, Input} from 'reactstrap';
 import Sapogov from './SpeechDistribution/Sapogov';
 import Yarkho from './SpeechDistribution/Yarkho';
 
-class SpeechDistribution extends Component {
-  render () {
-    const {groups, segments} = this.props;
+const SpeechDistribution = ({groups, segments}) => {
+  const [chartType, setChartType] = useState('sapogov');
 
-    return (
-      <div style={{width: '100%'}}>
-        <div className="speech-dist-container d-flex">
-          <div style={{position: 'relative', width: '90%'}}>
-            <Sapogov {...{groups, segments}}/>
-          </div>
-          <div style={{position: 'relative', width: '90%'}}>
-            <Yarkho {...{groups, segments}}/>
-          </div>
-        </div>
-        <br/>
-        <p>
-          {'Cf. '}
-          <a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">
-            Sapogov 1974
-          </a>
-          {', '}
-          <a href="http://rvb.ru/philologica/04/04iarxo.htm">
-            Yarkho 1997 (ru)
-          </a>
-          {', '}
-          <a href="https://doi.org/10.1515/jlt-2019-0002">
-            Yarkho 2019 (en)
-          </a>
-        </p>
-      </div>
-    );
+  let chart;
+  if (chartType === 'yarkho') {
+    chart = <Yarkho {...{groups, segments}}/>;
+  } else {
+    chart = <Sapogov {...{groups, segments}}/>;
   }
-}
+
+  const handleChange = e => setChartType(e.target.value);
+
+  return (
+    <div style={{width: '100%'}}>
+      <Form>
+        <FormGroup check inline>
+          <Label check>
+            <Input
+              type="radio"
+              value="sapogov"
+              checked={chartType === 'sapogov'}
+              onChange={handleChange}
+            /> Sapogov
+          </Label>
+        </FormGroup>
+        <FormGroup check inline>
+          <Label check>
+            <Input
+              type="radio"
+              value="yarkho"
+              checked={chartType === 'yarkho'}
+              onChange={handleChange}
+            /> Yarkho
+          </Label>
+        </FormGroup>
+      </Form>
+      <br/>
+      {chart}
+    </div>
+  );
+};
 
 SpeechDistribution.propTypes = {
   groups: PropTypes.array.isRequired,

--- a/src/components/SpeechDistribution/Sapogov.js
+++ b/src/components/SpeechDistribution/Sapogov.js
@@ -99,7 +99,17 @@ class Sapogov extends Component {
       options.scales.yAxes[0].ticks.stepSize = 1;
     }
 
-    return <Line data={data} options={options}/>;
+    return (
+      <>
+        <Line data={data} options={options}/>
+        <p>
+          {'Cf. '}
+          <a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">
+            Sapogov 1974
+          </a>
+        </p>
+      </>
+    );
   }
 }
 

--- a/src/components/SpeechDistribution/TrilckeFischer.js
+++ b/src/components/SpeechDistribution/TrilckeFischer.js
@@ -87,7 +87,7 @@ const TrilckeFischer = ({segments}) => {
             label={{
               value: `Drama Change Rate: ${dramaChangeRate.toFixed(3)}`,
               fill: 'rgba(79,181,198,1)',
-              position: 'top',
+              position: dramaChangeRate > 0.9 ? 'bottom' : 'top',
               fontSize: 12
             }}
             stroke="rgba(79,181,198,1)"

--- a/src/components/SpeechDistribution/TrilckeFischer.js
+++ b/src/components/SpeechDistribution/TrilckeFischer.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine
+} from 'recharts';
+
+function calcSegmentChangeRate (s1, s2) {
+  const all = [...new Set(s1.concat(s2))];
+  let edits = 0;
+  s1.forEach(s => {
+    if (!s2.includes(s)) {
+      edits += 1;
+    }
+  });
+  s2.forEach(s => {
+    if (!s1.includes(s)) {
+      edits += 1;
+    }
+  });
+  const changeRate = edits / all.length;
+  return changeRate;
+}
+
+function calcChangeRates (segments) {
+  const changeRates = [];
+  for (let i = 0; i < segments.length - 1; i++) {
+    const s1 = segments[i].speakers || [];
+    const s2 = segments[i + 1].speakers || [];
+    changeRates.push(calcSegmentChangeRate(s1, s2));
+  }
+
+  return changeRates;
+}
+
+const TrilckeFischer = ({segments}) => {
+  const changeRates = calcChangeRates(segments);
+  const dramaChangeRate = changeRates.reduce(
+    (acc, rate) => acc + rate,
+    0
+  ) / changeRates.length;
+
+  const data = changeRates.map((rate, i) => {
+    return {rate, transitionNum: i + 1};
+  });
+
+  return (
+    <>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart
+          data={data}
+        >
+          <CartesianGrid strokeDasharray="3 3"/>
+          <XAxis
+            dataKey="transitionNum"
+            scale="point"
+            label={{
+              value: 'segment transition no.',
+              position: 'insideBottom',
+              color: 'green',
+              fontSize: 12
+            }}
+            tick={{
+              fontSize: 10
+            }}
+          />
+          <YAxis
+            label={{
+              value: 'change rate',
+              angle: -90,
+              position: 'insideLeft',
+              fontSize: 12
+            }}
+            tick={{
+              fontSize: 10
+            }}
+          />
+          <Tooltip labelFormatter={v => `Transition ${v}`}/>
+          <ReferenceLine
+            y={dramaChangeRate}
+            label={{
+              value: `Drama Change Rate: ${dramaChangeRate.toFixed(3)}`,
+              fill: 'rgba(79,181,198,1)',
+              position: 'top',
+              fontSize: 12
+            }}
+            stroke="rgba(79,181,198,1)"
+            strokeWidth={2}
+            strokeDasharray="3 3"
+          />
+          <Line
+            dataKey="rate"
+            stroke="rgba(179,181,198,1)"
+            strokeWidth={3}
+            activeDot={{r: 4}}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+
+      <p>
+        {'Cf. '}
+        <a href="https://dh2017.adho.org/abstracts/071/071.pdf">
+          Trilcke/Fischer et al. 2017
+        </a>
+      </p>
+    </>
+  );
+};
+
+TrilckeFischer.propTypes = {
+  segments: PropTypes.array.isRequired
+};
+
+export default TrilckeFischer;

--- a/src/components/SpeechDistribution/Yarkho.js
+++ b/src/components/SpeechDistribution/Yarkho.js
@@ -143,7 +143,21 @@ class Yarkho extends Component {
       options.scales.yAxes[0].ticks.stepSize = 1;
     }
 
-    return <Line data={data} options={options}/>;
+    return (
+      <>
+        <Line data={data} options={options}/>
+        <p>
+          {'Cf. '}
+          <a href="http://rvb.ru/philologica/04/04iarxo.htm">
+            Yarkho 1997 (ru)
+          </a>
+          {', '}
+          <a href="https://doi.org/10.1515/jlt-2019-0002">
+            Yarkho 2019 (en)
+          </a>
+        </p>
+      </>
+    );
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,6 +2489,11 @@ bail@^1.0.0:
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
   integrity sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==
 
+balanced-match@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+  integrity sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -3477,6 +3482,11 @@ core-js@^2.5.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
+core-js@^2.6.10:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -4020,6 +4030,13 @@ d3-interpolate@1.1.6:
   dependencies:
     d3-color "1"
 
+d3-interpolate@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
 d3-path@1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
@@ -4078,6 +4095,18 @@ d3-scale@1.0.7:
     d3-time "1"
     d3-time-format "2"
 
+d3-scale@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
 d3-selection@1, d3-selection@^1.1.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.2.tgz#6e70a9df60801c8af28ac24d10072d82cbfdf652"
@@ -4092,6 +4121,13 @@ d3-shape@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
   integrity sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=
+  dependencies:
+    d3-path "1"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
 
@@ -4294,6 +4330,11 @@ decamelize@^2.0.0:
   integrity sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==
   dependencies:
     xregexp "4.0.0"
+
+decimal.js-light@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.0.tgz#ca7faf504c799326df94b0ab920424fdfc125348"
+  integrity sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -8047,7 +8088,7 @@ lodash.camelcase@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.debounce@^4:
+lodash.debounce@^4, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -8111,6 +8152,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -8146,6 +8192,11 @@ lodash.zip@^4.2.0:
 "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@~4.17.4:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.0.0:
   version "2.1.0"
@@ -8266,6 +8317,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+math-expression-evaluator@^1.2.14:
+  version "1.2.22"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz#c14dcb3d8b4d150e5dcea9c68c8dad80309b0d5e"
+  integrity sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -10269,7 +10325,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10413,7 +10469,7 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-raf@3.4.1, raf@^3.1.0:
+raf@3.4.1, raf@^3.1.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -10650,6 +10706,16 @@ react-redux@^4.x.x:
     loose-envify "^1.1.0"
     prop-types "^15.5.4"
 
+react-resize-detector@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-2.3.0.tgz#57bad1ae26a28a62a2ddb678ba6ffdf8fa2b599c"
+  integrity sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    prop-types "^15.6.0"
+    resize-observer-polyfill "^1.5.0"
+
 react-router-dom@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.1.tgz#ee66f4a5d18b6089c361958e443489d6bab714be"
@@ -10751,6 +10817,16 @@ react-sigma@^1.2.30:
   resolved "https://registry.yarnpkg.com/react-sigma/-/react-sigma-1.2.30.tgz#794f88e796c4f763158afe404d10d9635f848846"
   integrity sha512-8KVwKwHO9vrX1VohusZZm8ldMab32EHLZKkU1TrAnvSOHv6it6EEMwPOOtkJZOirnydKM0cXpxfFQv2LdBFAqQ==
 
+react-smooth@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.5.tgz#94ae161d7951cdd893ccb7099d031d342cb762ad"
+  integrity sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-transition-group "^2.5.0"
+
 react-transition-group@2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.3.tgz#26de363cab19e5c88ae5dbae105c706cf953bb92"
@@ -10761,7 +10837,7 @@ react-transition-group@2.5.3:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-transition-group@^2.3.1:
+react-transition-group@^2.3.1, react-transition-group@^2.5.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -10940,6 +11016,30 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recharts-scale@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.3.tgz#040b4f638ed687a530357292ecac880578384b59"
+  integrity sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==
+  dependencies:
+    decimal.js-light "^2.4.1"
+
+recharts@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.8.5.tgz#ca94a3395550946334a802e35004ceb2583fdb12"
+  integrity sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==
+  dependencies:
+    classnames "^2.2.5"
+    core-js "^2.6.10"
+    d3-interpolate "^1.3.0"
+    d3-scale "^2.1.0"
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.6.0"
+    react-resize-detector "^2.3.0"
+    react-smooth "^1.0.5"
+    recharts-scale "^0.4.2"
+    reduce-css-calc "^1.3.0"
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
@@ -10968,6 +11068,22 @@ redeyed@~1.0.0:
   integrity sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=
   dependencies:
     esprima "~3.0.0"
+
+reduce-css-calc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
+  integrity sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=
+  dependencies:
+    balanced-match "^0.4.2"
+    math-expression-evaluator "^1.2.14"
+    reduce-function-call "^1.0.1"
+
+reduce-function-call@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.3.tgz#60350f7fb252c0a67eb10fd4694d16909971300f"
+  integrity sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 redux-immutable@3.0.8:
   version "3.0.8"
@@ -11249,6 +11365,11 @@ reselect@^2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-2.5.4.tgz#b7d23fdf00b83fa7ad0279546f8dbbbd765c7047"
   integrity sha1-t9I/3wC4P6etAnlUb427vXZccEc=
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR adds a beat chart according to Trilcke/Fischer et al. to the speech distribution tab.

Since there was no easy why to draw drama change rate line with _react-chartjs-2_, we are introducing the [_recharts_](https://github.com/recharts/recharts) library to render this chart.

resolves #65