### PR TITLE
Fix jitter on certain page transitions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,27 +26,6 @@ body {
   padding: 0;
   font-family: sans-serif;
   background-color: var(--background);
-  transition: .3s ease-in-out;
-}
-
-::-webkit-scrollbar {
-  width: 0.5rem;
-  height: 0.5rem;
-  transition: .3s ease-in-out;
-}
-
-::-webkit-scrollbar:hover {
-    height: 1rem;
-    width: 1rem;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--background);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--main);
-  transition: .3s ease-in-out;
 }
 
 ul {


### PR DESCRIPTION
This PR removes the custom scrollbar styling on the main page. It causes an irritating jitter when transitioning between pages that are scrollable and those which are not. Also, visually, on first sight it looks like the layout is slightly broken: 

<img width="116" alt="image" src="https://user-images.githubusercontent.com/3439037/99875649-85fd1300-2bf1-11eb-9de6-c25fdae6160f.png">

For these reasons I'd prefer to leave the main scrollbar styling to the operating system.

The PR also removes the transition on the body element which causes an distracting zoom effect on the top navigation when navigating to the home page.