### PR TITLE
Draft: Refactor play details header

### DIFF
--- a/src/components/APIDoc.scss
+++ b/src/components/APIDoc.scss
@@ -1,4 +1,107 @@
-/* workaround class name collision between bootstrap and swagger-ui */
-.swagger-ui .col {
-  width: initial;
+.swagger-ui {
+  // workaround class name collision between bootstrap and swagger-ui
+  .col {
+    width: initial;
+  }
+
+  & > div {
+    margin-left: calc(var(--bootstrap-padding) * -1);
+    margin-right: calc(var(--bootstrap-padding) * -1);
+  }
+
+  &,
+  .info a,
+  .opblock-tag,
+  .opblock .opblock-summary-description,
+  .opblock .opblock-summary-method,
+  .opblock-description-wrapper p,
+  .opblock-external-docs-wrapper p,
+  .opblock-title_normal p,
+  p {
+    font-family: 'Rubik', sans-serif !important;
+  }
+
+  hgroup {
+    columns: 2;
+  }
+
+  .loading-container {
+    width: 100%;
+    margin: 0 !important;
+    display: inline-block !important;
+    padding: 0 !important;
+    background: var(--main);
+  }
+
+  .errors-wrapper {
+    margin: var(--x) 0 0 !important;
+    color: var(--main);
+    background: var(--background-light) !important;
+  }
+
+  .servers {
+    margin-top: .5rem;
+  }
+
+  .info {
+    columns: 2;
+    @media only screen and (max-width: 767px) {
+      columns: 1;
+    }
+
+    hgroup.main {
+      display: inline-grid;
+      .link {
+        color: var(--background-light);
+        padding: .1em .6em;
+        border-radius: 1em;
+        background-color: var(--primary-accent);
+        margin-left: .2em;
+        margin-top: 1em;
+        display: inline-block;
+        transition: .3s ease-in-out;
+        width: fit-content;
+        &:hover {
+          color: var(--secondary-accent);
+        }
+      }
+    }
+
+    .title {
+      font-size: calc(2.3 * var(--x)) !important;
+      color: var(--background-light) !important;
+      font-family: 'Rubik', sans-serif !important;
+      font-weight: 400;
+      text-decoration: underline;
+      text-decoration-color: var(--secondary-accent);
+    }
+
+    .title small {
+      background-color: var(--background-light) !important;
+      top: 0;
+      &:last-child {
+        background-color: var(--secondary-accent) !important;
+      }
+      pre {
+        color: var(--main) !important;
+      }
+    }
+  }
+
+  .wrapper {
+    padding: 0 !important;
+  }
+
+  .information-container {
+    background: var(--main);
+    .info {
+      margin: 0;
+    }
+  }
+
+  .scheme-container {
+    background: var(--background-color) !important;
+    box-shadow: none !important;
+    padding: var(--bootstrap-padding) !important;
+  }
 }

--- a/src/components/APIDoc.scss
+++ b/src/components/APIDoc.scss
@@ -45,12 +45,14 @@
 
   .info {
     columns: 2;
+    padding-bottom: 1rem;
     @media only screen and (max-width: 767px) {
       columns: 1;
     }
 
     hgroup.main {
       display: inline-grid;
+      margin-bottom: .5rem;
       .link {
         color: var(--background-light);
         padding: .1em .6em;

--- a/src/components/Corpus.js
+++ b/src/components/Corpus.js
@@ -4,6 +4,7 @@ import {DracorContext} from '../context';
 import api from '../api';
 import CorpusIndex from './CorpusIndex';
 import Play from './Play';
+import Header from './Header';
 import Footer from './Footer';
 
 function splitAuthorName (name) {
@@ -70,7 +71,7 @@ const Corpus = ({match, location}) => {
   if (match.url === location.pathname) {
     return (
       <div className="dracor-page">
-        <h1>{corpus.title}</h1>
+        <Header>{corpus.title}</Header>
         <CorpusIndex data={corpus}/>
         <Footer/>
       </div>

--- a/src/components/CorpusLabel.js
+++ b/src/components/CorpusLabel.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'react-router-dom';
+import classnames from 'classnames/bind';
+import style from './CorpusLabel.module.scss';
+
+const cx = classnames.bind(style);
+
+const CorpusLabel = ({name, title, id}) => {
+  return (
+    <span className={cx('main')}>
+      <Link to={`/${name}`} title={title || 'Corpus'}>
+        <em>{name}</em>Dracor
+      </Link>
+      {id && (
+        <span> | <Link to={`/id/${id}`}>{id}</Link></span>
+      )}
+    </span>
+  );
+};
+
+CorpusLabel.propTypes = {
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  title: PropTypes.string
+};
+
+CorpusLabel.defaultProps = {
+  id: null,
+  title: null
+};
+
+export default CorpusLabel;

--- a/src/components/CorpusLabel.module.scss
+++ b/src/components/CorpusLabel.module.scss
@@ -1,0 +1,42 @@
+.main {
+  display: inline-block;
+  background-color: var(--background-light);
+  color: var(--main);
+  padding: .2rem;
+  border-radius: .3em;
+  font-weight: 500;
+  font-size: 1.2rem;
+  border: 0;
+  width: fit-content;
+  transition: font-size .2s;
+  transition: background-color .2s ease-in-out;
+
+  &:hover {
+    background-color: var(--secondary-accent);
+  }
+
+  a {
+    color: var(--main);
+
+    em {
+      color: var(--background-light);
+      background-color: var(--main);
+      padding: 0 .25rem;
+      border-radius: .2em;
+      margin-right: .1em;
+      font-weight: 400;
+      font-style: normal;
+      text-transform: capitalize;
+    }
+  }
+
+  span {
+    font-weight: normal;
+
+    // DraCor ID link
+    a {
+      font-size: 85%;
+    }
+  }
+
+}

--- a/src/components/CorpusLabel.module.scss
+++ b/src/components/CorpusLabel.module.scss
@@ -37,6 +37,11 @@
     a {
       font-size: 85%;
     }
+
+    // hide in active sticky header
+    :global(.sticky-outer-wrapper.active) & {
+      display: none;
+    }
   }
 
 }

--- a/src/components/DocPage.js
+++ b/src/components/DocPage.js
@@ -1,8 +1,22 @@
-import React, {useEffect, useState} from 'react';
+import React, {createElement, useEffect, useState} from 'react';
 import ReactMarkdown from 'react-markdown';
 import {Helmet} from 'react-helmet';
+import {Col} from 'reactstrap';
 import axios from 'axios';
+import Header from './Header';
 import Footer from './Footer';
+
+const heading = ({level, children}) => {
+  if (level === 1) {
+    return (
+      <Header>
+        <Col tag="h1">{children}</Col>
+      </Header>
+    );
+  }
+
+  return createElement(`h${level}`, {}, children);
+};
 
 const DocPage = ({match}) => {
   const [markdown, setMarkdown] = useState('');
@@ -48,7 +62,7 @@ const DocPage = ({match}) => {
       <Helmet titleTemplate="%s - DraCor">
         <title>{title}</title>
       </Helmet>
-      <ReactMarkdown source={markdown}/>
+      <ReactMarkdown source={markdown} renderers={{heading}}/>
       <Footer/>
     </div>
   );

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,8 +1,12 @@
 import React, {useContext} from 'react';
+import classnames from 'classnames/bind';
 import {DracorContext} from '../context';
 import svgBibTex from '../images/bibtex.svg';
 import svgRIS from '../images/ris.svg';
 import svgCC0 from '../images/cc0.svg';
+import style from './Footer.module.scss';
+
+const cx = classnames.bind(style);
 
 const Footer = () => {
   const {apiInfo} = useContext(DracorContext);
@@ -13,8 +17,8 @@ const Footer = () => {
   }
 
   return (
-    <div className="footer">
-      <div className="citation">
+    <div className={cx('main')}>
+      <div className={cx('citation')}>
         <h5>
           If you want to cite DraCor, <wbr/>please use the following reference:
         </h5>
@@ -44,7 +48,7 @@ const Footer = () => {
           </a>.
         </p>
       </div>
-      <div className="license">
+      <div className={cx('license')}>
         <h5>Drama Corpora Project 2020</h5>
         <p>Unless otherwise stated, all corpora and the web design<br/> are released under Creative Commons
           {' '}

--- a/src/components/Footer.module.scss
+++ b/src/components/Footer.module.scss
@@ -1,0 +1,76 @@
+.main {
+  font-size: .9rem;
+  line-height: 1.65;
+  display: flex;
+  flex-flow: row wrap;
+  width: auto;
+  columns: 2;
+  gap: var(--x);
+  padding: var(--x);
+  background: linear-gradient(to top, #ebf0f6, #e3e8f1);
+  margin: 3em 0 0;
+
+  @media only screen and (max-width: 767px) {
+    flex-direction: column;
+  }
+
+  & > * {
+    flex: 1 1;
+    height: 100%;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+
+  h5 {
+    width: 100%;
+    white-space: nowrap;
+  }
+}
+
+
+.citation {
+  display: flex;
+  flex-flow: row wrap;
+  
+  p {
+    flex: 1 0 0;
+    place-self: flex-end;
+  }
+
+  img {
+    height: 5em;
+    padding-top: .3rem;
+    padding-right: 1rem;
+    transition: opacity .3s ease-in-out;
+    &:hover {
+      opacity: .85;
+    }
+  }
+}
+
+.license {
+  text-align: right;
+  white-space: nowrap;
+
+  a img {
+    margin: 0 0 .3rem .3rem;
+    height: 1.3rem;
+    @media only screen and (max-width: 767px) {
+      margin: 0 0 .3rem .3rem;
+    }
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .citation, .license {
+    width: 100%;
+    text-align: left;
+    margin-bottom: 1em;
+    // FIXME: remove <br> from license text
+    br {
+      display: none;
+    }
+  }
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Col, Row} from 'reactstrap';
+import classnames from 'classnames/bind';
+import style from './Header.module.scss';
+
+const cx = classnames.bind(style);
+
+/**
+ * The main header for a DraCor page
+ *
+ * The header provides a wrapping bootstrap row. Its children should be either
+ * a string or one or more bootstrap columns containing a h1 element.
+*/
+
+const Header = ({children, className}) => {
+  return (
+    <Row tag="header" className={cx(['main', className])}>
+      {typeof children === 'string' ? (
+        <Col tag="h1">{children}</Col>
+      ) : children}
+    </Row>
+  );
+};
+
+export default Header;

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -1,0 +1,17 @@
+.main {
+  color: var(--background-light);
+  background-color: var(--main);
+  padding-top: var(--x);
+  padding-bottom: var(--x);
+  margin-bottom: var(--x);
+
+  h1 {
+    text-decoration: underline;
+    text-decoration-color: var(--secondary-accent);
+    text-decoration-thickness: .1em;
+    font-size: 3rem;
+    font-weight: 400;
+    line-height: 1;
+    margin-bottom: 0;
+  }
+}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -4,7 +4,7 @@ import Footer from './Footer';
 
 const Home = () => {
   return (
-    <div>
+    <div className="row d-block">
       <Corpora/>
       <Footer/>
     </div>

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -1,12 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import {Helmet} from 'react-helmet';
 import Sticky from 'react-stickynode';
-import {Link} from 'react-router-dom';
 import api from '../api';
 import {makeGraph} from '../network';
+import PlayDetailsHeader from './PlayDetailsHeader';
 import PlayDetailsNav from './PlayDetailsNav';
-import IdLink from './IdLink';
-import Years from './Years';
 import CastList from './CastList';
 import DownloadLinks from './DownloadLinks';
 import NetworkGraph from './NetworkGraph';
@@ -110,59 +108,17 @@ const PlayInfo = ({corpusId, playId}) => {
     tabContent = <NetworkGraph {...{graph, nodeColor, edgeColor, play}}/>;
   }
 
-  const authors = play.authors.map(a => a.name).join(' · ');
+  const {authors, title} = play;
+  const authorNames = authors.map(a => a.name).join(' · ');
 
   return (
     <div className="h-100 d-md-flex flex-md-column dracor-page">
       <Helmet titleTemplate="%s - DraCor">
-        <title>{`${authors}: ${play.title}`}</title>
+        <title>{`${authorNames}: ${title}`}</title>
       </Helmet>
-      <hgroup className="play-header">
-        <h1>{play.title}</h1>
-        {play.subtitle && (
-          <h2 className="subtitle">
-            <em>{play.subtitle}</em>
-          </h2>
-        )}
-        <p className="years">
-          <Years
-            written={play.yearWritten}
-            premiere={play.yearPremiered}
-            print={play.yearPrinted}
-          />
-          {play.wikidataId && (
-            <span className="data-link-label">
-              {' '}
-              <IdLink>{`wikidata:${play.wikidataId}`}</IdLink>
-            </span>
-          )}
-        </p>
-        <ul className="play-meta">
-          <li>
-            DraCor: <a href={`/id/${play.id}`}>{play.id}</a>
-          </li>
-        </ul>
-      </hgroup>
 
       <Sticky enabled innerZ={1}>
-        <span>
-          <Link className="corpus-label" to={`/${play.corpus}`}>
-            <h4>
-              <span>{play.corpus}</span>DraCor
-            </h4>
-          </Link>
-          <div className="sticky-headings">
-            <h1>{play.title}</h1>
-            <span>
-              {play.authors.map(a => (
-                <h3 key={a.key} className="data-link-label" id="play-author">
-                  {a.name} {a.key && <IdLink>{a.key}</IdLink>}
-                </h3>
-              ))}
-            </span>
-          </div>
-        </span>
-
+        <PlayDetailsHeader play={play}/>
         <PlayDetailsNav
           items={
             // we remove relations from nav items if none are available for the

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -3,6 +3,7 @@ import {Helmet} from 'react-helmet';
 import Sticky from 'react-stickynode';
 import {Link} from 'react-router-dom';
 import api from '../api';
+import {makeGraph} from '../network';
 import PlayDetailsNav from './PlayDetailsNav';
 import IdLink from './IdLink';
 import Years from './Years';
@@ -31,66 +32,6 @@ const navItems = [
 
 const tabNames = new Set(navItems.map(item => item.name));
 
-function getCooccurrences (segments) {
-  const map = {};
-  segments.forEach(s => {
-    if (!s.speakers) {
-      return;
-    }
-
-    // make sure each speaker occurs only once in scene
-    const speakers = s.speakers.filter((v, i, a) => a.indexOf(v) === i);
-    speakers.forEach((c, i) => {
-      if (i < speakers.length - 1) {
-        const others = speakers.slice(i + 1);
-        others.forEach(o => {
-          const pair = [c, o].sort();
-          const key = pair.join('|');
-          if (map[key]) {
-            map[key][2]++;
-          } else {
-            map[key] = pair.concat(1);
-          }
-        });
-      }
-    });
-  });
-
-  const cooccurrences = [];
-  Object.keys(map)
-    .sort()
-    .forEach(key => {
-      cooccurrences.push(map[key]);
-    });
-
-  return cooccurrences;
-}
-
-function makeGraph (cast, segments) {
-  const nodes = [];
-  cast.forEach(p => {
-    nodes.push({id: p.id, label: p.name || `#${p.id}`});
-  });
-  const cooccurrences = getCooccurrences(segments);
-  const edges = [];
-  cooccurrences.forEach(cooc => {
-    edges.push({
-      id: cooc[0] + '|' + cooc[1],
-      source: cooc[0],
-      target: cooc[1],
-      size: cooc[2],
-      // NB: we set the edge color here since the defaultEdgeColor in Sigma
-      // settings does not to have any effect
-      color: edgeColor
-    });
-  });
-  return {nodes, edges};
-}
-
-// TODO: refactor to reduce complexity
-// see https://eslint.org/docs/rules/complexity
-/* eslint "complexity": ["error", 30] */
-
 const PlayInfo = ({corpusId, playId}) => {
   const [play, setPlay] = useState(null);
   const [graph, setGraph] = useState(null);
@@ -105,7 +46,7 @@ const PlayInfo = ({corpusId, playId}) => {
         const response = await api.get(url);
         if (response.ok) {
           const {cast, segments} = response.data;
-          const graph = makeGraph(cast, segments);
+          const graph = makeGraph(cast, segments, edgeColor);
           setPlay(response.data);
           setGraph(graph);
         } else if (response.status === 404) {

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -11,6 +11,7 @@ import CastList from './CastList';
 import DownloadLinks from './DownloadLinks';
 import NetworkGraph from './NetworkGraph';
 import RelationsGraph from './RelationsGraph';
+import Sources from './Sources';
 import SpeechDistribution from './SpeechDistribution';
 import TEIPanel from './TEIPanel';
 
@@ -26,8 +27,8 @@ const navItems = [
   {name: 'relations', label: 'Relations'},
   {name: 'speech', label: 'Speech distribution'},
   {name: 'text', label: 'Full text'},
-  {name: 'downloads', label: 'Downloads'}
-  // {name: 'sources', label: 'Sources'}
+  {name: 'downloads', label: 'Downloads'},
+  {name: 'sources', label: 'Sources'}
 ];
 
 const tabNames = new Set(navItems.map(item => item.name));
@@ -101,6 +102,8 @@ const PlayInfo = ({corpusId, playId}) => {
     tabContent = <DownloadLinks play={play}/>;
   } else if (tab === 'text') {
     tabContent = <TEIPanel url={teiUrl}/>;
+  } else if (tab === 'sources') {
+    tabContent = <Sources play={play}/>;
   } else if (tab === 'relations') {
     tabContent = <RelationsGraph {...{play, nodeColor, edgeColor}}/>;
   } else {
@@ -135,26 +138,6 @@ const PlayInfo = ({corpusId, playId}) => {
           )}
         </p>
         <ul className="play-meta">
-          {play.source && (
-            <li>
-              Source:{' '}
-              {play.source.url ? (
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={play.source.url}
-                >
-                  {play.source.name}
-                </a>
-              ) : (
-                play.source.name
-              )}
-            </li>
-          )}
-
-          {play.originalSource && (
-            <li>Original Source: {play.originalSource}</li>
-          )}
           <li>
             DraCor: <a href={`/id/${play.id}`}>{play.id}</a>
           </li>

--- a/src/components/PlayDetailsHeader.js
+++ b/src/components/PlayDetailsHeader.js
@@ -24,7 +24,7 @@ const PlayDetailsHeader = ({play}) => {
 
   return (
     <Header className={cx('main')}>
-      <Col md="8">
+      <Col className={cx('left')}>
         <h1>{title}</h1>
 
         {subtitle && <h2 className={cx('subtitle')}>{subtitle}</h2>}

--- a/src/components/PlayDetailsHeader.js
+++ b/src/components/PlayDetailsHeader.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import {Col} from 'reactstrap';
+import classnames from 'classnames/bind';
+import CorpusLabel from './CorpusLabel';
+import Header from './Header';
+import IdLink from './IdLink';
+import Years from './Years';
+import style from './PlayDetailsHeader.module.scss';
+
+const cx = classnames.bind(style);
+
+const PlayDetailsHeader = ({play}) => {
+  const {
+    id,
+    authors,
+    corpus,
+    title,
+    subtitle,
+    wikidataId,
+    yearPremiered,
+    yearPrinted,
+    yearWritten
+  } = play;
+
+  return (
+    <Header className={cx('main')}>
+      <Col md="8">
+        <h1>{title}</h1>
+
+        {subtitle && <h2 className={cx('subtitle')}>{subtitle}</h2>}
+
+        {authors.length > 0 && (
+          <h3 className={cx('authors')}>
+            {authors.map(a => (
+              <span key={a.key}>
+                {a.name}
+                {' '}
+                {a.key && (
+                  <span className="data-link-label">
+                    <IdLink>{a.key}</IdLink>
+                  </span>
+                )}
+              </span>
+            ))}
+          </h3>
+        )}
+      </Col>
+      <Col className={cx('right')}>
+        <CorpusLabel name={corpus} id={id}/>
+
+        {wikidataId && (
+          <span className="data-link-label">
+            {' '}
+            <IdLink showLabel>{`wikidata:${wikidataId}`}</IdLink>
+          </span>
+        )}
+
+        <p className={cx('years')}>
+          <Years
+            written={yearWritten}
+            premiere={yearPremiered}
+            print={yearPrinted}
+          />
+        </p>
+      </Col>
+    </Header>
+  );
+};
+
+export default PlayDetailsHeader;

--- a/src/components/PlayDetailsHeader.js
+++ b/src/components/PlayDetailsHeader.js
@@ -50,8 +50,7 @@ const PlayDetailsHeader = ({play}) => {
 
         {wikidataId && (
           <span className="data-link-label">
-            {' '}
-            <IdLink showLabel>{`wikidata:${wikidataId}`}</IdLink>
+            <IdLink>{`wikidata:${wikidataId}`}</IdLink>
           </span>
         )}
 

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -1,0 +1,121 @@
+.main {
+  h1 {
+    // shrink in active sticky header
+    :global(.sticky-outer-wrapper.active) & {
+      font-size: 1.73em;
+      padding-right: var(--x);
+      text-decoration: underline;
+      text-decoration-color: var(--secondary-accent);
+      text-decoration-thickness: .1em;
+    }
+  }
+}
+
+.subtitle {
+  margin: .6rem 0 0;
+  font-size: 1.3em;
+  font-weight: 400;
+  font-style: italic;
+
+  // hide in active sticky header
+  :global(.sticky-outer-wrapper.active) & {
+    display: none;
+  }
+}
+
+.authors {
+  margin: .6rem 0 0;
+  font-weight: normal;
+  line-height: 1;
+  color: var(--background-light);
+  transition: font-size .2s;
+
+  // single author wrapper
+  & > span {
+    display: block;
+    padding-bottom: .1em;
+
+    // wikidata link
+    span[class~=data-link-label] {
+      font-size: .6em;
+      vertical-align: middle;
+      // hide in active sticky header
+      :global(.sticky-outer-wrapper.active) & {
+        display: none;
+      }
+    }
+  }
+
+  // active sticky header
+  :global(.sticky-outer-wrapper.active) & {
+    padding-top: .1em;
+    font-size: 1em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    & > span {
+      display: inline-block;
+    }
+    
+    & > span::before {
+      content: '·';
+      margin: 0 .5rem;
+    }
+    
+    & > span:first-child::before {
+      content: '';
+      margin: 0;
+    }
+  }
+}
+
+.right {
+  text-align: right;
+
+  span[class~=data-link-label] {
+    display: block;
+    margin-top: var(--x);
+
+    // hide in active sticky header
+    :global(.sticky-outer-wrapper.active) & {
+      display: none;
+    }
+  }
+
+  @media only screen and (max-width: 767px) {
+    text-align: left;
+    padding-top: calc(var(--x) * 1.5);
+    margin-top: .3rem;
+    display: inline;
+    span[class~=data-link-label] {
+      display: inline;
+      &::before {
+        content: '';
+        display: block;
+      }
+    }
+  }
+}
+
+.years {
+  margin-top: var(--x);
+  span {
+    margin-left: 1rem;
+  }
+
+  @media only screen and (max-width: 767px) {
+    margin-top: .3rem;
+    margin-left: 1em;
+    display: inline-block;
+    span {
+      margin-right: 1em;
+      margin-left: 0;
+    }
+  }
+
+  // hide in active sticky header
+  :global(.sticky-outer-wrapper.active) & {
+    display: none;
+  }
+}

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -3,11 +3,66 @@
     // shrink in active sticky header
     :global(.sticky-outer-wrapper.active) & {
       font-size: 1.73em;
-      padding-right: var(--x);
       text-decoration: underline;
       text-decoration-color: var(--secondary-accent);
       text-decoration-thickness: .1em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
+  }
+
+  @media only screen and (max-width: 767px) {
+    flex-direction: column;
+    :global(.sticky-outer-wrapper.active) & {
+      flex-direction: row;
+    }
+  }
+}
+
+.left {
+  // leave room for corpus label in active sticky header
+  :global(.sticky-outer-wrapper.active) & {
+    width: 70%;
+  }
+}
+
+.right {
+  text-align: right;
+
+  span[class~=data-link-label] {
+    display: block;
+    margin-top: var(--x);
+
+    // hide in active sticky header
+    :global(.sticky-outer-wrapper.active) & {
+      display: none;
+    }
+  }
+
+  @media only screen and (max-width: 767px) {
+    text-align: left;
+    padding-top: calc(var(--x) * 1.5);
+    margin-top: .3rem;
+    display: inline;
+    span[class~=data-link-label] {
+      display: inline;
+      // spacing with corpus label
+      &::before {
+        content: '';
+        display: block;
+        margin: .5rem;
+      }
+    }
+  }
+
+  // in active sticky header
+  :global(.sticky-outer-wrapper.active) & {
+    padding-top: 0;
+    padding-left: 0;
+    margin-top: 0;
+    width: 30%;
+    text-align: right;
   }
 }
 
@@ -66,34 +121,6 @@
     & > span:first-child::before {
       content: '';
       margin: 0;
-    }
-  }
-}
-
-.right {
-  text-align: right;
-
-  span[class~=data-link-label] {
-    display: block;
-    margin-top: var(--x);
-
-    // hide in active sticky header
-    :global(.sticky-outer-wrapper.active) & {
-      display: none;
-    }
-  }
-
-  @media only screen and (max-width: 767px) {
-    text-align: left;
-    padding-top: calc(var(--x) * 1.5);
-    margin-top: .3rem;
-    display: inline;
-    span[class~=data-link-label] {
-      display: inline;
-      &::before {
-        content: '';
-        display: block;
-      }
     }
   }
 }

--- a/src/components/PlayDetailsNav.module.scss
+++ b/src/components/PlayDetailsNav.module.scss
@@ -1,4 +1,6 @@
 .main {
+  // override margin of preceding PageDetailsHeader
+  margin-top: calc(var(--x) * -1);
   flex-flow: nowrap;
   white-space: nowrap;
   margin-left: auto;

--- a/src/components/PlayDetailsNav.module.scss
+++ b/src/components/PlayDetailsNav.module.scss
@@ -1,11 +1,13 @@
 .main {
+  // FIXME: this overrides the boostrap grid, we should find a more compatible
+  // solution.
+  margin-left: calc(var(--bootstrap-padding) * -1);
+  margin-right: calc(var(--bootstrap-padding) * -1);
   // override margin of preceding PageDetailsHeader
   margin-top: calc(var(--x) * -1);
   flex-flow: nowrap;
   white-space: nowrap;
-  margin-left: auto;
   border-bottom: none;
-  width: 100%;
   overflow-x: auto;
   -ms-overflow-style: none;
   overflow: -moz-scrollbars-none;

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Sources = ({play}) => {
+  const {source, originalSource} = play;
+  return (
+    <div>
+      {!(source || originalSource) && (
+        <p>No source information available</p>
+      )}
+
+      {source && (
+        <p>
+          {'Source: '}
+          {play.source.url ? (
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={play.source.url}
+            >
+              {play.source.name}
+            </a>
+          ) : (
+            play.source.name
+          )}
+        </p>
+      )}
+
+      {originalSource && (
+        <p>Original Source: {play.originalSource}</p>
+      )}
+    </div>
+  );
+};
+
+Sources.propTypes = {
+  play: PropTypes.object.isRequired
+};
+
+export default Sources;

--- a/src/components/TopNav.js
+++ b/src/components/TopNav.js
@@ -12,9 +12,13 @@ import {
 } from 'reactstrap';
 import {faGithub} from '@fortawesome/free-brands-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import classnames from 'classnames/bind';
 import {ezlinavisUrl} from '../config';
 import CorporaDropdown from './CorporaDropdown';
 import TopNavDropdown from './TopNavDropdown';
+import style from './TopNav.module.scss';
+
+const cx = classnames.bind(style);
 
 const TopNav = () => {
   const [navOpen, setNavOpen] = useState(false);
@@ -23,11 +27,11 @@ const TopNav = () => {
 
   return (
     <Headroom disable disableInlineStyles upTolerance={50}>
-      <Navbar expand="md" className="dracor-navbar">
+      <Navbar expand="md" className={cx('base')}>
         <NavbarBrand title="Drama Corpora Project (DraCor)" href="/"/>
         <NavbarToggler onClick={toggleNav}/>
         <Collapse navbar isOpen={navOpen}>
-          <Nav navbar tag="div" className="dracor-mainnav">
+          <Nav navbar tag="div" className={cx('main')}>
             <TopNavDropdown
               label="About" items={[
                 {label: 'What is DraCor?', to: '/doc/what-is-dracor'},
@@ -56,7 +60,7 @@ const TopNav = () => {
               </RouterNavLink>
             </NavItem>
           </Nav>
-          <Nav navbar className="dracor-github">
+          <Nav navbar className={cx('github')}>
             <NavItem>
               <NavLink
                 href="https://github.com/dracor-org"

--- a/src/components/TopNav.js
+++ b/src/components/TopNav.js
@@ -26,7 +26,7 @@ const TopNav = () => {
   const toggleNav = () => setNavOpen(!navOpen);
 
   return (
-    <Headroom disable disableInlineStyles upTolerance={50}>
+    <Headroom upTolerance={20}>
       <Navbar expand="md" className={cx('base')}>
         <NavbarBrand title="Drama Corpora Project (DraCor)" href="/"/>
         <NavbarToggler onClick={toggleNav}/>

--- a/src/components/TopNav.module.scss
+++ b/src/components/TopNav.module.scss
@@ -1,4 +1,5 @@
 .base {
+  background-color: var(--main);
   // main entries in top navigation
   :global(.navbar-nav .nav-item),
   :global(.navbar-nav .dropdown .dropdown-toggle)
@@ -66,4 +67,9 @@
       border-bottom: solid var(--secondary-accent) .17em;
     }
   }
+}
+
+// make sure dropdown open above sticky header
+:global(.headroom-wrapper) {
+  z-index: 2;
 }

--- a/src/components/TopNav.module.scss
+++ b/src/components/TopNav.module.scss
@@ -1,0 +1,69 @@
+.base {
+  // main entries in top navigation
+  :global(.navbar-nav .nav-item),
+  :global(.navbar-nav .dropdown .dropdown-toggle)
+  {
+    font-size: 1.2em;
+    font-weight: 400;
+    text-transform: uppercase;
+  }
+
+  :global(.dropdown-item.active) {
+    color: var(--main);
+    background-color: var(--secondary-accent);
+  }
+
+  :global(.navbar-brand) {
+    content: ' ';
+    background-image: url(../images/DraCor-white.svg);
+    background-repeat: no-repeat;
+    margin: 0;
+    padding: 0;
+    font-size: 1em;
+    // FIXME: use bootsrap grid
+    width: calc(2 * var(--x));
+    height: calc(2 * var(--x));
+    @media only screen and (max-width: 1440px) {
+      width: calc(3 * var(--x));
+      height: calc(3 * var(--x));
+    }
+  }
+}
+
+// centered main navigation
+.main {
+  margin: auto;
+}
+
+// GitHub link
+.github {
+  margin: 0;
+  padding: 0;
+  border-bottom: none;
+  // FIXME: use bootsrap grid
+  width: calc(2 * var(--x));
+  height: calc(2 * var(--x));
+  @media only screen and (max-width: 1440px) {
+    width: calc(3 * var(--x));
+    height: calc(3 * var(--x));
+  }
+
+  :global(.fa-github) {
+    width: 100%;
+    height: 100%;
+    font-size: 1rem;
+  }
+
+  :global(.nav-item .nav-link:hover) {
+    border-bottom: none;
+  }
+
+  @media only screen and (max-width: 767px) {
+    width: auto;
+    height: auto;
+
+    :global(.nav-item .nav-link:hover) {
+      border-bottom: solid var(--secondary-accent) .17em;
+    }
+  }
+}

--- a/src/components/Yasgui.js
+++ b/src/components/Yasgui.js
@@ -6,6 +6,7 @@ import Header from './Header';
 import Footer from './Footer';
 
 import 'yasgui/dist/yasgui.min.css';
+import './Yasgui.scss';
 
 const endpoint = sparqlUrl;
 

--- a/src/components/Yasgui.js
+++ b/src/components/Yasgui.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import {Helmet} from 'react-helmet';
 import yasgui from 'yasgui/dist/yasgui';
 import {sparqlUrl, shortenerUrl as urlShortener} from '../config';
+import Header from './Header';
 import Footer from './Footer';
 
 import 'yasgui/dist/yasgui.min.css';
@@ -43,7 +44,7 @@ class Yasgui extends Component {
         <Helmet titleTemplate="%s - DraCor">
           <title>SPARQL</title>
         </Helmet>
-        <h1>SPARQL</h1>
+        <Header>SPARQL</Header>
         <div id="yasgui"/>
         <Footer/>
       </div>

--- a/src/components/Yasgui.scss
+++ b/src/components/Yasgui.scss
@@ -1,0 +1,40 @@
+.yasgui {
+  z-index: 0;
+
+  .nav-tabs {
+    background-color: var(--background);
+
+    li a[role=addTab] {
+      padding: 0 .5em !important;
+    }
+
+    & > li > a {
+      border-radius: 8px 8px 0 0 !important;
+    }
+
+  }
+
+  .tab-content {
+    box-shadow: 0 7px 5px 0 rgba(0, 0, 0, 0.2), 0 10px 1em 0 rgba(0,0,0,.08);
+  }
+
+  .yasr {
+    padding-bottom: 5px;
+
+    .yasr_btn {
+      &.selected, &:focus {
+        background-color: var(--main) !important;
+        border-color: var(--main) !important;
+      }
+    }
+  }
+
+  svg {
+    vertical-align: inherit;
+    fill: var(--main);
+  }
+
+  a {
+    color: var(--main) !important;
+  }
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -82,42 +82,6 @@ a:hover {
   display: none;
 }
 
-/* #HEADROOM */
-
-.headroom-wrapper {
-  z-index: 2;
-}
-
-.headroom {
-  background: var(--main);
-  top: 0;
-  left: 0;
-  right: 0;
-}
-
-.headroom--unfixed {
-  transform: translateY(0);
-  position: relative;
-}
-
-.headroom--scrolled {
-  transition: transform 200ms ease-in-out;
-}
-
-.headroom--unpinned {
-  position: relative;
-  transform: translateY(-100%);
-}
-
-.headroom--pinned {
-  position: fixed;
-  transform: translateY(0%);
-  left: 0;
-  right: 0;
-  z-Index: 2;
-  box-shadow: 0 5px 5px 0 var(--shadow), 0 4px 0px 0 var(--main-shadow);
-}
-
 /* ############################# */
 /* #PAGE                       # */
 /* ############################# */
@@ -137,8 +101,8 @@ a:hover {
 .content::before {
   content: '';
   background: var(--main);
-  height: 10em;
-  top: -10em;
+  height: 100em;
+  top: -100em;
   width: 100%;
   display: block;
   position: absolute;
@@ -471,7 +435,6 @@ table.table.corpus th:focus {
   box-shadow: 0 7px 5px 0 rgba(0, 0, 0, 0.2), 0 10px 1em 0 rgba(0,0,0,.08), 0 4px 0px 0 #33405220;
 }
 
-
 .nav-tabs .nav-link {
   font-size: 1.2em;
   padding: .5em 0;
@@ -751,9 +714,6 @@ table.table.corpus th:focus {
 }
 
 @media only screen and (max-width: 767px) {
-  .headroom-wrapper {
-    height: auto !important;
-  }
   // FIXME: move navbar overrides to TopNav.module.scss
   .navbar .navbar-toggler-icon {
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="rgb(255, 255, 255)"><rect y="0" width="100%" height="12%" rx="0%" ry="0%" /><rect y="40%" width="100%" height="12%" rx="0%" ry="0%" /><rect y="80%" width="100%" height="12%" rx="0%" ry="0%" /></svg>') center / 100% 100% no-repeat;

--- a/src/index.scss
+++ b/src/index.scss
@@ -243,160 +243,6 @@ a:hover {
 }
 
 /* ############################# */
-/* #STICKY                     # */
-/* ############################# */
-
-.sticky-outer-wrapper {
-  /* FIXME: This is an invisible trigger to activate the sticky header. Since
-     Headroom (when active) decreases the viewport height of a page by
-     disappearing (positon: fixed;) after scrolling down, the trigger has to be
-     moved accordingly. This should probably be revised when refactoring the
-     header (https://github.com/dracor-org/dracor-frontend/pull/130).
-   */
-  margin: 0;
-  padding-top: calc(var(--x) * 8);
-  margin-top: calc(var(--x) * (-8));
-}
-
-.sticky-inner-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  background: var(--main);
-  padding-right: var(--x);
-}
-
-.sticky-inner-wrapper > span {
-  padding: var(--x) var(--x) 0;
-  width: 100%;
-  display: flex;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -ms-overflow-style: none;
-  overflow: -moz-scrollbars-none;
-  white-space: nowrap;
-}
-
-.sticky-inner-wrapper > span::-webkit-scrollbar {
-  display: none;
-}
-
-.sticky-inner-wrapper > span::after {
-  content: '';
-  width: var(--x);
-  height: 2em;
-  background-image: linear-gradient(to left, var(--main),var(--main-transparent));
-  position: absolute;
-  right: var(--x);
-}
-
-.sticky-headings {
-  display: inline-flex;
-  flex-flow: column;
-}
-
-.sticky-headings span {
-  display: inline-flex;
-}
-
-.sticky-headings h3 {
-  padding: 0 0 0 .5rem;
-}
-
-.sticky-headings h3::before {
-  content: '·';
-  margin-right: .5rem;
-}
-
-.sticky-headings h3:first-of-type {
-  padding-left: 1rem;
-}
-
-.sticky-headings h3:last-of-type {
-  padding-right: var(--x);
-}
-
-.sticky-headings h3:first-of-type::before {
-  content: '';
-  margin: 0;
-}
-
-.sticky-inner-wrapper h1:first-of-type {
-  font-size: 0;
-  padding: 0;
-  transition: font-size .2s;
-  text-decoration: none;
-}
-
-.sticky-outer-wrapper.active h1:first-of-type {
-  font-size: 1.73em;
-  padding-left: 1rem;
-  padding-right: var(--x);
-  text-decoration: underline;
-  text-decoration-color: var(--secondary-accent);
-  text-decoration-thickness: .1em;
-}
-
-.sticky-inner-wrapper h3 {
-  font-weight: normal;
-  line-height: 1;
-  color: var(--background-light);
-  margin: 0;
-  transition: font-size .2s;
-}
-
-.sticky-inner-wrapper h3 span {
-  font-size: .6em;
-  vertical-align: middle;
-}
-
-.sticky-outer-wrapper.active {
-  padding: 0;
-  margin: 0;
-}
-
-.sticky-outer-wrapper.active h3 {
-  padding-top: .42em;
-  font-size: 1em;
-}
-
-.sticky-outer-wrapper.active h3 span {
-  display: none;
-}
-
-.sticky-outer-wrapper.active .corpus-label h4 {
-  font-size: 2.1rem;
-  padding: .35rem;
-}
-
-.corpus-label h4 {
-  background-color: var(--background-light);
-  color: var(--main);
-  padding: .2rem;
-  margin-bottom: 0;
-  border-radius: .3em;
-  font-weight: 500;
-  font-size: 1.2rem;
-  border: 0;
-  width: fit-content;
-  transition: font-size .2s;
-  transition: background-color .2s ease-in-out;
-}
-
-.corpus-label h4:hover {
-  background-color: var(--secondary-accent);
-}
-
-.sticky-inner-wrapper h4 span {
-  color: var(--background-light);
-  background-color: var(--main);
-  padding: 0 .25rem;
-  border-radius: .2em;
-  margin-right: .1em;
-  font-weight: 400;
-  text-transform: capitalize;
-}
-
-/* ############################# */
 /* #SLIDER                     # */
 /* ############################# */
 
@@ -654,37 +500,6 @@ table.table.corpus th:focus {
 /* ############################# */
 /* #PLAY                       # */
 /* ############################# */
-
-.play-header {
-  margin: 0;
-  padding-top: var(--x);
-  columns: 2;
-  gap: 0;
-  background: var(--main);
-}
-
-.play-header > *, .play-header h1:first-of-type {
-  padding: 0 var(--x) var(--x);
-  margin: 0;
-}
-
-.play-header .subtitle {
-  font-size: 1.3em;
-  font-weight: 400;
-}
-
-.play-header li {
-  list-style: none;
-}
-
-.play-header .years span {
-  margin-right: 1rem;
-}
-
-.play-meta {
-  font-size: .85em;
-  flex: 1;
-}
 
 .dashboard-wrapper {
   display: block;
@@ -1151,15 +966,11 @@ table.table.corpus th:focus {
     width: 94vw;
     margin-top: .5em;
   }
-  .play-header {
-    columns: 1;
-  }
+
   .content-wrapper, .cast-list-wrapper {
     width: 100%;
   }
- .sticky-outer-wrapper.active .sticky-inner-wrapper > span::after {
-   height: 4em;
- }
+
   #dashboard {
     height: auto;
   }
@@ -1167,16 +978,13 @@ table.table.corpus th:focus {
     flex-direction: column;
   }
 
-  .sticky-inner-wrapper > span {
-    width: 100%;
-    padding-bottom: 0;
-  }
   .swagger-ui .info {
     columns: 1;
   }
   .swagger-ui .loading-container {
     width: 100%;
   }
+
   .footer {
     flex-direction: column;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -575,49 +575,6 @@ table.table.corpus th:focus {
 }
 
 /* ############################# */
-/* #SWAGGER & YASGUI STYLES    # */
-/* ############################# */
-
-.yasgui {
-  z-index: 0;
-}
-
-.yasgui .nav-tabs {
-  background-color: var(--background);
-}
-
-.yasgui .yasr {
-  padding-bottom: 5px;
-}
-
-.yasgui .tab-content {
-  box-shadow: 0 7px 5px 0 rgba(0, 0, 0, 0.2), 0 10px 1em 0 rgba(0,0,0,.08);
-}
-
-.yasgui .yasr .yasr_btn.selected, .yasgui .yasr .yasr_btn:focus {
-  background-color: var(--main) !important;
-  border-color: var(--main) !important;
-}
-
-.yasgui svg {
-  vertical-align: inherit;
-  fill: var(--main);
-}
-
-.yasgui .nav-tabs li a[role=addTab] {
-  padding: 0 .5em !important;
-}
-
-.yasgui .nav-tabs>li>a {
-  border-radius: 8px 8px 0 0 !important;
-}
-
-.yasgui a {
-  color: var(--main) !important;
-}
-
-
-/* ############################# */
 /* #FOOTER                     # */
 /* ############################# */
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,6 +11,7 @@
   --primary-accent: #0088ff;
   --secondary-accent: #aaeeff;
   --x: 2rem;
+  --bootstrap-padding: 15px;
 }
 
 html, #root {
@@ -191,13 +192,6 @@ a:hover {
   position: absolute;
 }
 
-.container-fluid {
-  padding: 0;
-}
-
-.dracor-page > * {
-  margin: var(--x);
-}
 .dracor-page hgroup {
   color: var(--background-light);
   background-color: var(--main);

--- a/src/index.scss
+++ b/src/index.scss
@@ -574,68 +574,6 @@ table.table.corpus th:focus {
   border-radius: .25rem;
 }
 
-/* ############################# */
-/* #FOOTER                     # */
-/* ############################# */
-
-.footer {
-  font-size: .9rem;
-  line-height: 1.65;
-  display: flex;
-  flex-flow: row wrap;
-  width: auto;
-  columns: 2;
-  gap: var(--x);
-  padding: var(--x);
-  background: linear-gradient(to top, #ebf0f6, #e3e8f1);
-  margin: 1em 0 0;
-}
-
-.footer p {
-  margin-bottom: 0;
-}
-
-.footer h5 {
-  width: 100%;
-  white-space: nowrap;
-}
-
-.footer > * {
-  flex: 1 1;
-  height: 100%;
-}
-
-.citation {
-  display: flex;
-  flex-flow: row wrap;
-}
-
-.citation img {
-  height: 5em;
-  padding-top: .3rem;
-  padding-right: 1rem;
-  transition: opacity .3s ease-in-out;
-}
-
-.citation img:hover {
-  opacity: .85;
-}
-
-.citation p {
-  flex: 1 0 0;
-  place-self: flex-end;
-}
-
-.license {
-  text-align: right;
-  white-space: nowrap;
-}
-
-.license a img {
-  margin: 0 0 .3rem .3rem;
-  height: 1.3rem;
-}
-
 .version-pill {
   white-space: nowrap;
 }
@@ -733,17 +671,6 @@ table.table.corpus th:focus {
     flex-direction: column;
   }
 
-  .footer {
-    flex-direction: column;
-  }
-  .citation, .license {
-    width: 100%;
-    text-align: left;
-    margin-bottom: 1em;
-  }
-  .license a img {
-    margin: 0 0 .3rem .3rem;
-  }
   .current-year {
     display: none;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -49,27 +49,10 @@ a:hover {
 /* #NAVIGATION                 # */
 /* ############################# */
 
+// FIXME: move navbar overrides to TopNav.module.scss
 .navbar {
   padding: var(--x);
   z-index: 2;
-}
-
-/* centered top navigation */
-.dracor-mainnav {
-  margin: auto;
-}
-
-/* main entries in top navigation */
-.dracor-navbar .navbar-nav .nav-item,
-.dracor-navbar .navbar-nav .dropdown .dropdown-toggle {
-  font-size: 1.2em;
-  font-weight: 400;
-  text-transform: uppercase;
-}
-
-.dracor-navbar .dropdown-item.active {
-  color: var(--main);
-  background-color: var(--secondary-accent);
 }
 
 .navbar .navbar-nav .nav-link {
@@ -95,40 +78,9 @@ a:hover {
   margin-right: 0;
 }
 
-.navbar-brand, .dracor-github {
-  width: calc(2 * var(--x));
-  height: calc(2 * var(--x));
-}
-
-.navbar-brand {
-  content: ' ';
-  background-image: url(./images/DraCor-white.svg);
-  background-repeat: no-repeat;
-  margin: 0;
-  padding: 0;
-  font-size: 1em;
-}
-
-.dracor-github {
-  margin: 0;
-  padding: 0;
-  border-bottom: none;
-}
-
 .nav-link span {
   display: none;
 }
-
-.dracor-github .nav-item .nav-link:hover {
-  border-bottom: none;
-}
-
-.nav-link .fa-github {
-  width: 100%;
-  height: 100%;
-  font-size: 1rem;
-}
-
 
 /* #HEADROOM */
 
@@ -796,16 +748,13 @@ table.table.corpus th:focus {
   .content-wrapper, .cast-list-wrapper {
     height: calc(100vh - (var(--x) * 11 + .2rem));
   }
-  .navbar-brand, .dracor-github {
-    width: calc(3 * var(--x));
-    height: calc(3 * var(--x));
-  }
 }
 
 @media only screen and (max-width: 767px) {
   .headroom-wrapper {
     height: auto !important;
   }
+  // FIXME: move navbar overrides to TopNav.module.scss
   .navbar .navbar-toggler-icon {
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="rgb(255, 255, 255)"><rect y="0" width="100%" height="12%" rx="0%" ry="0%" /><rect y="40%" width="100%" height="12%" rx="0%" ry="0%" /><rect y="80%" width="100%" height="12%" rx="0%" ry="0%" /></svg>') center / 100% 100% no-repeat;
   }
@@ -835,13 +784,6 @@ table.table.corpus th:focus {
   }
   .navbar-collapse {
     padding-top: 1em;
-  }
-  .dracor-github {
-    width: auto;
-    height: auto;
-  }
-  .dracor-github .nav-item .nav-link:hover {
-    border-bottom: solid var(--secondary-accent) .17em;
   }
   .corpus-card {
     width: calc(100vw - 2.5em);

--- a/src/index.scss
+++ b/src/index.scss
@@ -701,104 +701,6 @@ table.table.corpus th:focus {
   color: var(--main) !important;
 }
 
-.swagger-ui .loading-container {
-  width: 100%;
-  margin: 0 !important;
-  display: inline-block !important;
-  padding: 0 !important;
-  background: var(--main);
-}
-
-.swagger-ui .errors-wrapper {
-  margin: var(--x) 0 0 !important;
-}
-
-.swagger-ui, .swagger-ui .opblock-tag, .swagger-ui .opblock .opblock-summary-description, .swagger-ui .opblock .opblock-summary-method, .swagger-ui .opblock-description-wrapper p, .swagger-ui .opblock-external-docs-wrapper p, .swagger-ui .opblock-title_normal p, .swagger-ui p {
-  font-family: 'Rubik', sans-serif !important;
-}
-
-.swagger-ui .info hgroup.main {
-  margin: 0 !important;
-  display: inline-grid;
-}
-
-.swagger-ui .info .title {
-  font-size: calc(2.3 * var(--x)) !important;
-  color: var(--background-light) !important;
-  font-family: 'Rubik', sans-serif !important;
-  font-weight: 400;
-  text-decoration: underline;
-  text-decoration-color: var(--secondary-accent);
-}
-
-.swagger-ui .wrapper {
-  padding: var(--x) !important;
-  margin: 0 !important;
-  width: 100%;
-  max-width: none !important;
-}
-
-.swagger-ui .information-container {
-  padding: 0 !important;
-}
-
-.swagger-ui hgroup {
-  columns: 2;
-}
-
-.swagger-ui .info hgroup.main .link {
-  color: var(--background-light);
-  padding: .1em .6em;
-  border-radius: 1em;
-  background-color: var(--primary-accent);
-  margin-left: .2em;
-  margin-top: 1em;
-  display: inline-block;
-  transition: .3s ease-in-out;
-  width: fit-content;
-}
-
-.swagger-ui .info hgroup.main .link:hover {
-  color: var(--secondary-accent);
-}
-
-.swagger-ui .info {
-    background: var(--main);
-    margin: 0 !important;
-    padding: var(--x);
-    columns: 2;
-}
-
-.swagger-ui .info a {
-  font-family: 'Rubik', sans-serif !important;
-}
-
-.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm, .col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md, .col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg, .col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl, .col-xl-auto {
-    padding: 0 !important;
-}
-
-.swagger-ui .scheme-container {
-  background: var(--background-color) !important;
-  box-shadow: none !important;
-  padding: 0 !important;
-}
-
-.swagger-ui .info .title small {
-  background-color: var(--background-light) !important;
-}
-
-.swagger-ui .info .title small pre {
-  color: var(--main) !important;
-}
-
-.swagger-ui .info .title small:last-child {
-  background-color: var(--secondary-accent) !important;
-}
-
-.swagger-ui .errors-wrapper {
-  color: var(--main);
-  background: var(--background-light) !important;
-}
 
 /* ############################# */
 /* #FOOTER                     # */
@@ -970,13 +872,6 @@ table.table.corpus th:focus {
   }
   #dashboard > div {
     flex-direction: column;
-  }
-
-  .swagger-ui .info {
-    columns: 1;
-  }
-  .swagger-ui .loading-container {
-    width: 100%;
   }
 
   .footer {

--- a/src/index.scss
+++ b/src/index.scss
@@ -44,18 +44,6 @@ a:hover {
   box-shadow: none;
 }
 
-hgroup {
-  color: var(--background-light);
-}
-
-h2 {
-  padding-top: calc(2 * var(--x));
-}
-
-h3, h4 {
-  padding-top: var(--x);
-}
-
 /* ############################# */
 /* #NAVIGATION                 # */
 /* ############################# */
@@ -210,18 +198,9 @@ h3, h4 {
 .dracor-page > * {
   margin: var(--x);
 }
-
-.dracor-page h1:first-of-type {
+.dracor-page hgroup {
   color: var(--background-light);
-  text-decoration: underline;
-  text-decoration-color: var(--secondary-accent);
-  text-decoration-thickness: .1em;
   background-color: var(--main);
-  font-size: 3rem;
-  font-weight: 400;
-  line-height: 1;
-  margin: 0;
-  padding: var(--x);
 }
 
 .loading {

--- a/src/network.js
+++ b/src/network.js
@@ -1,0 +1,57 @@
+// network graph utility functions
+
+function getCooccurrences (segments) {
+  const map = {};
+  segments.forEach(s => {
+    if (!s.speakers) {
+      return;
+    }
+
+    // make sure each speaker occurs only once in scene
+    const speakers = s.speakers.filter((v, i, a) => a.indexOf(v) === i);
+    speakers.forEach((c, i) => {
+      if (i < speakers.length - 1) {
+        const others = speakers.slice(i + 1);
+        others.forEach(o => {
+          const pair = [c, o].sort();
+          const key = pair.join('|');
+          if (map[key]) {
+            map[key][2]++;
+          } else {
+            map[key] = pair.concat(1);
+          }
+        });
+      }
+    });
+  });
+
+  const cooccurrences = [];
+  Object.keys(map)
+    .sort()
+    .forEach(key => {
+      cooccurrences.push(map[key]);
+    });
+
+  return cooccurrences;
+}
+
+export function makeGraph (cast, segments, edgeColor = 'black') {
+  const nodes = [];
+  cast.forEach(p => {
+    nodes.push({id: p.id, label: p.name || `#${p.id}`});
+  });
+  const cooccurrences = getCooccurrences(segments);
+  const edges = [];
+  cooccurrences.forEach(cooc => {
+    edges.push({
+      id: cooc[0] + '|' + cooc[1],
+      source: cooc[0],
+      target: cooc[1],
+      size: cooc[2],
+      // NB: we set the edge color here since the defaultEdgeColor in Sigma
+      // settings does not to have any effect
+      color: edgeColor
+    });
+  });
+  return {nodes, edges};
+}


### PR DESCRIPTION
This PR mainly refactors the header of the play detail page with the goal of modularising the dracor CSS and clearly separating it from customisations of third-party libraries like `react-stickynode` or `swagger-ui`. In particular it

- reintroduces utilisation of the bootstrap grid using  reactstrap's `Row` and `Col` components
- introduces a general `Header` component making sure the page header fits into the grid
- introduces a special `PlayDetailsHeader` for the play details page adding a more complex layout to `Header`
- introduces several other components (`CorpusLabel`, `Sources`)
- moves large chunks of CSS into SCSS modules
