### PR TITLE
Update index.scss

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -682,6 +682,7 @@ table.table.corpus th:focus {
   columns: 2;
   gap: 0;
   background: var(--main);
+  z-index: 1;
 }
 
 .play-header > *, .play-header h1:first-of-type {


### PR DESCRIPTION
Fixed play header overlapping in Firefox by assigning a higher z-index to the element