### PR TITLE
Header and grid fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, {useState, useEffect} from 'react';
 import {BrowserRouter as Router, Route, Redirect, Switch} from 'react-router-dom';
-import {Container} from 'reactstrap';
 import api from './api';
 import {DracorContext} from './context';
 import asyncComponent from './components/AsyncComponent';
@@ -64,16 +63,14 @@ const App = () => {
             <Redirect to="/doc/what-is-dracor"/>
           </Route>
           <Route path="/" component={TopNav}/>
-          <div className="content d-flex" style={{flex: 1}}>
-            <Container fluid>
-              <Switch>
-                <Route exact path="/" component={Home}/>
-                <Route exact path="/sparql" component={AsyncYasgui}/>
-                <Route exact path="/doc/api" component={AsyncAPIDoc}/>
-                <Route path="/doc/:slug" component={DocPage}/>
-                <Route path="/:corpusId" component={Corpus}/>
-              </Switch>
-            </Container>
+          <div>
+            <Switch>
+              <Route exact path="/" component={Home}/>
+              <Route exact path="/sparql" component={AsyncYasgui}/>
+              <Route exact path="/doc/api" component={AsyncAPIDoc}/>
+              <Route path="/doc/:slug" component={DocPage}/>
+              <Route path="/:corpusId" component={Corpus}/>
+            </Switch>
           </div>
         </div>
       </DracorContext.Provider>

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -1,0 +1,9 @@
+@mixin pagetitle {
+  text-decoration: underline;
+  text-decoration-color: var(--secondary-accent);
+  text-decoration-thickness: .1em;
+  font-size: 3rem;
+  font-weight: 400;
+  line-height: 1;
+  margin-bottom: 0;
+}

--- a/src/components/APIDoc.js
+++ b/src/components/APIDoc.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {Container} from 'reactstrap';
 import {Helmet} from 'react-helmet';
 import SwaggerUI from 'swagger-ui-react';
 import Footer from './Footer';
@@ -9,13 +10,13 @@ import './APIDoc.scss';
 class APIDoc extends Component {
   render () {
     return (
-      <div>
+      <Container fluid>
         <Helmet titleTemplate="%s - DraCor">
           <title>API Documentation</title>
         </Helmet>
         <SwaggerUI url="/api.yaml"/>
         <Footer/>
-      </div>
+      </Container>
     );
   }
 }

--- a/src/components/Corpus.js
+++ b/src/components/Corpus.js
@@ -1,5 +1,6 @@
 import React, {useState, useEffect, useContext} from 'react';
 import {Route} from 'react-router-dom';
+import {Container} from 'reactstrap';
 import {DracorContext} from '../context';
 import api from '../api';
 import CorpusIndex from './CorpusIndex';
@@ -54,11 +55,13 @@ const Corpus = ({match, location}) => {
 
   if (match.url === location.pathname) {
     return (
-      <div className="dracor-page">
-        <Header>{corpus.title}</Header>
-        <CorpusIndex data={corpus}/>
-        <Footer/>
-      </div>
+      <Container fluid>
+        <div className="dracor-page">
+          <Header>{corpus.title}</Header>
+          <CorpusIndex data={corpus}/>
+          <Footer/>
+        </div>
+      </Container>
     );
   }
 

--- a/src/components/DocPage.js
+++ b/src/components/DocPage.js
@@ -1,7 +1,7 @@
 import React, {createElement, useEffect, useState} from 'react';
 import ReactMarkdown from 'react-markdown';
 import {Helmet} from 'react-helmet';
-import {Col} from 'reactstrap';
+import {Container, Col} from 'reactstrap';
 import axios from 'axios';
 import Header from './Header';
 import Footer from './Footer';
@@ -58,13 +58,15 @@ const DocPage = ({match}) => {
   }, [slug]);
 
   return (
-    <div className="dracor-page">
-      <Helmet titleTemplate="%s - DraCor">
-        <title>{title}</title>
-      </Helmet>
-      <ReactMarkdown source={markdown} renderers={{heading}}/>
-      <Footer/>
-    </div>
+    <Container fluid>
+      <div className="dracor-page">
+        <Helmet titleTemplate="%s - DraCor">
+          <title>{title}</title>
+        </Helmet>
+        <ReactMarkdown source={markdown} renderers={{heading}}/>
+        <Footer/>
+      </div>
+    </Container>
   );
 };
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,5 @@
 import React, {useContext} from 'react';
+import {Col, Row} from 'reactstrap';
 import classnames from 'classnames/bind';
 import {DracorContext} from '../context';
 import svgBibTex from '../images/bibtex.svg';
@@ -17,8 +18,8 @@ const Footer = () => {
   }
 
   return (
-    <div className={cx('main')}>
-      <div className={cx('citation')}>
+    <Row className={cx('main')}>
+      <Col className={cx('citation')}>
         <h5>
           If you want to cite DraCor, <wbr/>please use the following reference:
         </h5>
@@ -47,8 +48,8 @@ const Footer = () => {
             doi:10.5281/zenodo.4284002
           </a>.
         </p>
-      </div>
-      <div className={cx('license')}>
+      </Col>
+      <Col className={cx('license')}>
         <h5>Drama Corpora Project 2020</h5>
         <p>Unless otherwise stated, all corpora and the web design<br/> are released under Creative Commons
           {' '}
@@ -95,8 +96,8 @@ const Footer = () => {
             </span>
           </p>
         )}
-      </div>
-    </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/components/Footer.module.scss
+++ b/src/components/Footer.module.scss
@@ -1,18 +1,10 @@
 .main {
   font-size: .9rem;
   line-height: 1.65;
-  display: flex;
-  flex-flow: row wrap;
-  width: auto;
-  columns: 2;
-  gap: var(--x);
-  padding: var(--x);
+  padding-top: var(--bootstrap-padding);
+  padding-bottom: var(--bootstrap-padding);
   background: linear-gradient(to top, #ebf0f6, #e3e8f1);
-  margin: 3em 0 0;
-
-  @media only screen and (max-width: 767px) {
-    flex-direction: column;
-  }
+  margin-top: 3em;
 
   & > * {
     flex: 1 1;
@@ -28,7 +20,6 @@
     white-space: nowrap;
   }
 }
-
 
 .citation {
   display: flex;
@@ -65,8 +56,8 @@
 
 @media only screen and (max-width: 767px) {
   .citation, .license {
-    width: 100%;
     text-align: left;
+    white-space: normal;
     margin-bottom: 1em;
     // FIXME: remove <br> from license text
     br {

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -1,3 +1,5 @@
+@import "../mixins.scss";
+
 .main {
   color: var(--background-light);
   background-color: var(--main);
@@ -6,12 +8,6 @@
   margin-bottom: var(--x);
 
   h1 {
-    text-decoration: underline;
-    text-decoration-color: var(--secondary-accent);
-    text-decoration-thickness: .1em;
-    font-size: 3rem;
-    font-weight: 400;
-    line-height: 1;
-    margin-bottom: 0;
+    @include pagetitle;
   }
 }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Container} from 'reactstrap';
 import Corpora from './Corpora';
 import Footer from './Footer';
 
@@ -6,7 +7,9 @@ const Home = () => {
   return (
     <div className="row d-block">
       <Corpora/>
-      <Footer/>
+      <Container fluid>
+        <Footer/>
+      </Container>
     </div>
   );
 };

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -5,12 +5,12 @@ import Footer from './Footer';
 
 const Home = () => {
   return (
-    <div className="row d-block">
-      <Corpora/>
-      <Container fluid>
-        <Footer/>
-      </Container>
-    </div>
+    <Container fluid>
+      <div className="row d-block">
+        <Corpora/>
+      </div>
+      <Footer/>
+    </Container>
   );
 };
 

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
 import {Helmet} from 'react-helmet';
 import api from '../api';
 import {makeGraph} from '../network';
@@ -167,13 +168,19 @@ const PlayInfo = ({corpusId, playId}) => {
       <Helmet titleTemplate="%s - DraCor">
         <title>{`${authors}: ${play.title}`}</title>
       </Helmet>
-      <PlayDetailsHeader play={play}/>
-      <PlayDetailsNav items={items} current={tab}/>
+      <PlayDetailsHeader play={play}>
+        <PlayDetailsNav items={items} current={tab}/>
+      </PlayDetailsHeader>
       <PlayDetailsTab sidebar={sidebar} description={description}>
         {tabContent}
       </PlayDetailsTab>
     </div>
   );
+};
+
+PlayInfo.propTypes = {
+  corpusId: PropTypes.string,
+  playId: PropTypes.string
 };
 
 export default PlayInfo;

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
+import {Container} from 'reactstrap';
 import {Helmet} from 'react-helmet';
 import api from '../api';
 import {makeGraph} from '../network';
@@ -171,9 +172,11 @@ const PlayInfo = ({corpusId, playId}) => {
       <PlayDetailsHeader play={play}>
         <PlayDetailsNav items={items} current={tab}/>
       </PlayDetailsHeader>
-      <PlayDetailsTab sidebar={sidebar} description={description}>
-        {tabContent}
-      </PlayDetailsTab>
+      <Container fluid>
+        <PlayDetailsTab sidebar={sidebar} description={description}>
+          {tabContent}
+        </PlayDetailsTab>
+      </Container>
     </div>
   );
 };

--- a/src/components/PlayDetailsHeader.js
+++ b/src/components/PlayDetailsHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Col} from 'reactstrap';
 import classnames from 'classnames/bind';
 import Sticky from 'react-stickynode';
@@ -10,7 +11,7 @@ import style from './PlayDetailsHeader.module.scss';
 
 const cx = classnames.bind(style);
 
-const PlayDetailsHeader = ({play}) => {
+const PlayDetailsHeader = ({play, children}) => {
   const {
     id,
     authors,
@@ -66,10 +67,26 @@ const PlayDetailsHeader = ({play}) => {
               </span>
             </div>
           </span>
+          {children}
         </Sticky>
       </Col>
     </Header>
   );
+};
+
+PlayDetailsHeader.propTypes = {
+  play: PropTypes.shape({
+    id: PropTypes.string,
+    authors: PropTypes.array,
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    corpus: PropTypes.string,
+    wikidataId: PropTypes.string,
+    yearPremiered: PropTypes.string,
+    yearPrinted: PropTypes.string,
+    yearWritten: PropTypes.string
+  }),
+  children: PropTypes.element
 };
 
 export default PlayDetailsHeader;

--- a/src/components/PlayDetailsHeader.js
+++ b/src/components/PlayDetailsHeader.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Col} from 'reactstrap';
 import classnames from 'classnames/bind';
 import Sticky from 'react-stickynode';
 import CorpusLabel from './CorpusLabel';
-import Header from './Header';
 import IdLink from './IdLink';
 import Years from './Years';
 import style from './PlayDetailsHeader.module.scss';
@@ -25,52 +23,50 @@ const PlayDetailsHeader = ({play, children}) => {
   } = play;
 
   return (
-    <Header className={cx('main')}>
-      <Col>
-        <div className={cx('title')}>
-          <h1>{title}</h1>
+    <div className={cx('main')}>
+      <div className={cx('title')}>
+        <h1>{title}</h1>
 
-          {subtitle && <h2 className={cx('subtitle')}>{subtitle}</h2>}
+        {subtitle && <h2 className={cx('subtitle')}>{subtitle}</h2>}
 
-          <p className={cx('years')}>
-            <Years
-              written={yearWritten}
-              premiere={yearPremiered}
-              print={yearPrinted}
-            />
-            {wikidataId && (
-              <span className="data-link-label">
-                {' '}
-                <IdLink>{`wikidata:${wikidataId}`}</IdLink>
-              </span>
-            )}
-          </p>
+        <p className={cx('years')}>
+          <Years
+            written={yearWritten}
+            premiere={yearPremiered}
+            print={yearPrinted}
+          />
+          {wikidataId && (
+            <span className="data-link-label">
+              {' '}
+              <IdLink>{`wikidata:${wikidataId}`}</IdLink>
+            </span>
+          )}
+        </p>
 
-          <ul className={cx('meta')}>
-            <li>
-              DraCor: <a href={`/id/${id}`}>{id}</a>
-            </li>
-          </ul>
-        </div>
+        <ul className={cx('meta')}>
+          <li>
+            DraCor: <a href={`/id/${id}`}>{id}</a>
+          </li>
+        </ul>
+      </div>
 
-        <Sticky enabled innerZ={1}>
-          <span>
-            <CorpusLabel name={corpus}/>
-            <div className={cx('sticky-headings')}>
-              <h1>{title}</h1>
-              <span>
-                {authors.map(a => (
-                  <h3 key={a.key} className="data-link-label">
-                    {a.fullname}{' '} {a.key && <IdLink>{a.key}</IdLink>}
-                  </h3>
-                ))}
-              </span>
-            </div>
-          </span>
-          {children}
-        </Sticky>
-      </Col>
-    </Header>
+      <Sticky enabled innerZ={1}>
+        <span>
+          <CorpusLabel name={corpus}/>
+          <div className={cx('sticky-headings')}>
+            <h1>{title}</h1>
+            <span>
+              {authors.map(a => (
+                <h3 key={a.key} className="data-link-label">
+                  {a.fullname}{' '} {a.key && <IdLink>{a.key}</IdLink>}
+                </h3>
+              ))}
+            </span>
+          </div>
+        </span>
+        {children}
+      </Sticky>
+    </div>
   );
 };
 

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -136,6 +136,14 @@
       position: absolute;
       right: var(--x);
     }
+
+    @media (max-width: 767px) {
+      width: 100%;
+      padding-bottom: 0;
+      :global(.sticky-outer-wrapper):global(.active) &::after {
+        height: 4em;
+      }
+    }
   }
 
   h1:first-of-type {

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -1,8 +1,20 @@
-.main {
-  // wraps the title, years and meta information
-  padding-bottom: 0;
+@import "../mixins.scss";
 
+.main {
+  color: var(--background-light);
+  background-color: var(--main);
+  padding-top: var(--x);
+  padding-bottom: 0;
+  margin-bottom: var(--bootstrap-padding);
+  h1 {
+    @include pagetitle;
+  }
+
+  // wraps the title, years and meta information
   .title {
+    padding-left: var(--bootstrap-padding);
+    padding-right: var(--bootstrap-padding);
+
     columns: 2;
     @media (max-width: 767px) {
       columns: 1;
@@ -112,7 +124,9 @@
   display: flex;
   flex-wrap: wrap;
   background: var(--main);
-  padding-right: var(--x);
+  padding-left: var(--bootstrap-padding);
+  padding-right: var(--bootstrap-padding);
+  // padding-right: var(--x);
 
   & > span {
     padding: var(--x) 0 0;

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -5,7 +5,7 @@
   background-color: var(--main);
   padding-top: var(--x);
   padding-bottom: 0;
-  margin-bottom: var(--bootstrap-padding);
+
   h1 {
     @include pagetitle;
   }
@@ -86,15 +86,7 @@
 }
 
 :global(.sticky-outer-wrapper) {
-  /* FIXME: This is an invisible trigger to activate the sticky header. Since
-     Headroom (when active) decreases the viewport height of a page by
-     disappearing (positon: fixed;) after scrolling down, the trigger has to be
-     moved accordingly. This should probably be revised when refactoring the
-     header (https://github.com/dracor-org/dracor-frontend/pull/130).
-   */
   margin: 0;
-  padding-top: calc(var(--x) * 8);
-  margin-top: calc(var(--x) * (-8));
 
   &:global(.active) {
     padding: 0;
@@ -129,8 +121,9 @@
   // padding-right: var(--x);
 
   & > span {
-    padding: var(--x) 0 0;
+    padding: var(--bootstrap-padding) 0 0;
     width: 100%;
+    min-height: 4em;
     display: flex;
     overflow-x: auto;
     overflow-y: hidden;

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -1,5 +1,7 @@
 .main {
   // wraps the title, years and meta information
+  padding-bottom: 0;
+
   .title {
     columns: 2;
     grid-gap: 0;

--- a/src/components/PlayDetailsHeader.module.scss
+++ b/src/components/PlayDetailsHeader.module.scss
@@ -4,6 +4,9 @@
 
   .title {
     columns: 2;
+    @media (max-width: 767px) {
+      columns: 1;
+    }
     grid-gap: 0;
     gap: 0;
     background: var(--main);
@@ -27,9 +30,15 @@
 
   .meta {
     font-size: .85em;
-    flex: 1 1;
+    padding-left: 0;
+    margin-bottom: 0.5rem;
     li {
       list-style: none;
+    }
+
+    @media (max-width: 767px) {
+      text-align: left;
+      margin-bottom: 0;
     }
   }
 }

--- a/src/components/PlayDetailsNav.module.scss
+++ b/src/components/PlayDetailsNav.module.scss
@@ -3,8 +3,8 @@
   // solution.
   margin-left: calc(var(--bootstrap-padding) * -1);
   margin-right: calc(var(--bootstrap-padding) * -1);
-  // override margin of preceding PageDetailsHeader
-  margin-top: calc(var(--x) * -1);
+
+  margin-top: .5rem;
   flex-flow: nowrap;
   white-space: nowrap;
   border-bottom: none;

--- a/src/components/PlayDetailsNav.module.scss
+++ b/src/components/PlayDetailsNav.module.scss
@@ -4,7 +4,6 @@
   margin-left: calc(var(--bootstrap-padding) * -1);
   margin-right: calc(var(--bootstrap-padding) * -1);
 
-  margin-top: .5rem;
   flex-flow: nowrap;
   white-space: nowrap;
   border-bottom: none;
@@ -12,16 +11,16 @@
   -ms-overflow-style: none;
   overflow: -moz-scrollbars-none;
   background: var(--main);
-  padding: 0 var(--x);
-  min-height: 2rem;
+  padding: 0 var(--bootstrap-padding);
+  min-height: 2em;
 
   &::after {
     content: '';
-    width: var(--x);
+    width: var(--bootstrap-padding);
     height: 2.5em;
     background-image: linear-gradient(to left, var(--main),var(--main-transparent));
     position: absolute;
-    right: var(--x);
+    right: 0;
   }
 
   &::-webkit-scrollbar {
@@ -30,7 +29,7 @@
 
   @media only screen and (max-width: 767px) {
     & {
-      padding: 0 var(--x);
+      padding: 0 var(--bootstrap-padding);
     }
     
     & li:last-child::after {

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -36,7 +36,7 @@
 .content, .sidebar {
   height: calc(100vh - (8em - 1px) - (var(--bootstrap-padding) * 3));
   @media only screen and (max-width: 1440px) {
-    height: calc(100vh - (8em - 3px) - (var(--bootstrap-padding) * 3);
+    height: calc(100vh - (8em - 3px) - (var(--bootstrap-padding) * 3));
   }
   @media only screen and (max-width: 767px) {
     width: 100%;

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -34,9 +34,9 @@
 }
 
 .content, .sidebar {
-  height: calc(100vh - (var(--x) * 6.5 + 1em));
+  height: calc(100vh - (8em - 1px) - (var(--bootstrap-padding) * 3));
   @media only screen and (max-width: 1440px) {
-    height: calc(100vh - (var(--x) * 11 + .2rem));
+    height: calc(100vh - (8em - 3px) - (var(--bootstrap-padding) * 3);
   }
   @media only screen and (max-width: 767px) {
     width: 100%;

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -53,7 +53,9 @@
   @media only screen and (max-width: 767px) {
     min-height: calc(100vh - 4.2em);
     overflow-y: hidden;
+    width: auto;
     height: auto;
+    margin-right: 0;
   }
 }
 
@@ -63,6 +65,7 @@
 
   @media only screen and (max-width: 767px) {
     margin-top: 2em;
+    width: auto;
     height: auto;
   }
 }

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -33,7 +33,21 @@
   }
 }
 
+
+
+
 .content, .sidebar {
+  // Since sigma canvas requires a calculated height to fill available space on
+  // the page we have to subtract all heights that are not canvas:
+  //   1em padding-top on .main > div > div
+  //   1em padding-bottom on .main > div > div
+  //   1 var(--bootstrap-padding) padding-top on .main
+  //   1 var(--bootstrap-padding) padding-bottom on .main
+  //   1 var(--bootstrap-padding) padding-top on .sticky-inner-wrapper > span
+  //   4em min-height on .sticky-inner-wrapper > span
+  //   2em min-height on .PlayDetailsNav_main
+  //
+  // And leave at least one pixel to trigger the sticky header – that's the "-1px".
   height: calc(100vh - (8em - 1px) - (var(--bootstrap-padding) * 3));
   @media only screen and (max-width: 1440px) {
     height: calc(100vh - (8em - 3px) - (var(--bootstrap-padding) * 3));

--- a/src/components/Yasgui.js
+++ b/src/components/Yasgui.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {Container} from 'reactstrap';
 import {Helmet} from 'react-helmet';
 import yasgui from 'yasgui/dist/yasgui';
 import {sparqlUrl, shortenerUrl as urlShortener} from '../config';
@@ -41,14 +42,16 @@ class Yasgui extends Component {
 
   render () {
     return (
-      <div className="dracor-page">
-        <Helmet titleTemplate="%s - DraCor">
-          <title>SPARQL</title>
-        </Helmet>
-        <Header>SPARQL</Header>
-        <div id="yasgui"/>
-        <Footer/>
-      </div>
+      <Container fluid>
+        <div className="dracor-page">
+          <Helmet titleTemplate="%s - DraCor">
+            <title>SPARQL</title>
+          </Helmet>
+          <Header>SPARQL</Header>
+          <div id="yasgui"/>
+          <Footer/>
+        </div>
+      </Container>
     );
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -638,9 +638,6 @@ table.table.corpus th:focus {
     width: 94vw;
     margin-top: .5em;
   }
-  .play-header {
-    columns: 1;
-  }
  .sticky-outer-wrapper.active .sticky-inner-wrapper > span::after {
    height: 4em;
  }

--- a/src/index.scss
+++ b/src/index.scss
@@ -647,10 +647,6 @@ table.table.corpus th:focus {
     padding-bottom: 0;
   }
 
-  .current-year {
-    display: none;
-  }
-
   .tei-frame {
     overflow-y: hidden;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -638,14 +638,6 @@ table.table.corpus th:focus {
     width: 94vw;
     margin-top: .5em;
   }
- .sticky-outer-wrapper.active .sticky-inner-wrapper > span::after {
-   height: 4em;
- }
-
-  .sticky-inner-wrapper > span {
-    width: 100%;
-    padding-bottom: 0;
-  }
 
   .tei-frame {
     overflow-y: hidden;


### PR DESCRIPTION
This PR fixes several layout issues mostly on mobile devices, that were introduced by the previous refactoring. In particular:

- columns in `PlayDetailsHeader`
- mobile behaviour of the sticky header
- width of the sidebar contents