### PR TITLE
Play tabs grid implementation

### DIFF
--- a/src/components/NetworkGraph.js
+++ b/src/components/NetworkGraph.js
@@ -9,7 +9,6 @@ import {
   RelativeSize,
   RandomizeNodePositions
 } from 'react-sigma/lib/';
-import PlayMetrics from './PlayMetrics';
 
 class NetworkGraph extends Component {
   render () {
@@ -56,7 +55,6 @@ class NetworkGraph extends Component {
             {layout}
             <RelativeSize initialSize={15}/>
           </RandomizeNodePositions>
-          <div className="metrics"><PlayMetrics play={play}/></div>
         </Sigma>
       );
     }

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -14,6 +14,7 @@ import NetworkGraph from './NetworkGraph';
 import RelationsGraph from './RelationsGraph';
 import SpeechDistribution, {SpeechDistributionNav} from './SpeechDistribution';
 import TEIPanel from './TEIPanel';
+import PlayMetrics from './PlayMetrics';
 
 import './Play.scss';
 
@@ -97,9 +98,12 @@ const PlayInfo = ({corpusId, playId}) => {
 
   const castList = <CastList hasTitle cast={play.cast || []}/>;
 
+  const playMetrics = <PlayMetrics play={play}/>;
+
   let tabContent = null;
   let description = null;
   let sidebar = null;
+  let metrics = null;
 
   if (tab === 'speech') {
     tabContent = (
@@ -149,6 +153,7 @@ const PlayInfo = ({corpusId, playId}) => {
   } else {
     tabContent = <NetworkGraph {...{graph, nodeColor, edgeColor, play}}/>;
     sidebar = castList;
+    metrics = playMetrics;
     description = (
       <p>
         This tab shows a co-occurrence network. If characters appear in the
@@ -173,7 +178,7 @@ const PlayInfo = ({corpusId, playId}) => {
         <PlayDetailsNav items={items} current={tab}/>
       </PlayDetailsHeader>
       <Container fluid>
-        <PlayDetailsTab sidebar={sidebar} description={description}>
+        <PlayDetailsTab sidebar={sidebar} description={description} metrics={metrics}>
           {tabContent}
         </PlayDetailsTab>
       </Container>

--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -102,7 +102,7 @@ const PlayInfo = ({corpusId, playId}) => {
 
   let tabContent = null;
   let description = null;
-  let sidebar = null;
+  let cast = null;
   let metrics = null;
 
   if (tab === 'speech') {
@@ -113,16 +113,11 @@ const PlayInfo = ({corpusId, playId}) => {
         {...{groups}}
       />
     );
-    sidebar = (
+    description = (
       <SpeechDistributionNav
         type={chartType}
         onChange={type => setChartType(type)}
       />
-    );
-    description = (
-      <p>
-        This tab shows different ways of visualising speech distribution.
-      </p>
     );
   } else if (tab === 'downloads') {
     tabContent = <DownloadLinks play={play}/>;
@@ -140,7 +135,7 @@ const PlayInfo = ({corpusId, playId}) => {
     );
   } else if (tab === 'relations') {
     tabContent = <RelationsGraph {...{play, nodeColor, edgeColor}}/>;
-    sidebar = castList;
+    cast = castList;
     description = (
       <p>
         This tab visualises kinship and other relationship data, following the
@@ -152,7 +147,7 @@ const PlayInfo = ({corpusId, playId}) => {
     );
   } else {
     tabContent = <NetworkGraph {...{graph, nodeColor, edgeColor, play}}/>;
-    sidebar = castList;
+    cast = castList;
     metrics = playMetrics;
     description = (
       <p>
@@ -178,7 +173,7 @@ const PlayInfo = ({corpusId, playId}) => {
         <PlayDetailsNav items={items} current={tab}/>
       </PlayDetailsHeader>
       <Container fluid>
-        <PlayDetailsTab sidebar={sidebar} description={description} metrics={metrics}>
+        <PlayDetailsTab cast={cast} description={description} metrics={metrics}>
           {tabContent}
         </PlayDetailsTab>
       </Container>

--- a/src/components/PlayDetailsTab.js
+++ b/src/components/PlayDetailsTab.js
@@ -5,7 +5,7 @@ import style from './PlayDetailsTab.module.scss';
 
 const cx = classnames.bind(style);
 
-const PlayDetailsTab = ({children, description, sidebar}) => {
+const PlayDetailsTab = ({children, description, sidebar, metrics}) => {
   return (
     <div className={cx('main')}>
       <div>
@@ -20,6 +20,7 @@ const PlayDetailsTab = ({children, description, sidebar}) => {
                   {description}
                 </div>
               )}
+              {metrics}
               {sidebar}
             </div>
           )}
@@ -32,6 +33,7 @@ const PlayDetailsTab = ({children, description, sidebar}) => {
 PlayDetailsTab.propTypes = {
   sidebar: PropTypes.element,
   description: PropTypes.element,
+  metrics: PropTypes.element,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node

--- a/src/components/PlayDetailsTab.js
+++ b/src/components/PlayDetailsTab.js
@@ -5,33 +5,31 @@ import style from './PlayDetailsTab.module.scss';
 
 const cx = classnames.bind(style);
 
-const PlayDetailsTab = ({children, description, sidebar, metrics}) => {
+const PlayDetailsTab = ({children, description, cast, metrics}) => {
   return (
     <div className={cx('main')}>
-      <div>
-        <div>
           <div className={cx('content')}>
             {children}
           </div>
-          {(sidebar || description) && (
-            <div className={cx('sidebar', 'dracor-scrollbar')}>
-              {description && (
-                <div className={cx('description')}>
-                  {description}
-                </div>
-              )}
+          <div className={cx('description')}>
+            {description}
+          </div>
+          {(metrics) && (
+            <div className={cx('metrics')}>
               {metrics}
-              {sidebar}
+            </div>
+          )}
+          {(cast) && (
+            <div className={cx('cast', 'dracor-scrollbar')}>
+              {cast}
             </div>
           )}
         </div>
-      </div>
-    </div>
   );
 };
 
 PlayDetailsTab.propTypes = {
-  sidebar: PropTypes.element,
+  cast: PropTypes.element,
   description: PropTypes.element,
   metrics: PropTypes.element,
   children: PropTypes.oneOfType([
@@ -41,7 +39,7 @@ PlayDetailsTab.propTypes = {
 };
 
 PlayDetailsTab.defaultProps = {
-  sidebar: null
+  cast: null
 };
 
 export default PlayDetailsTab;

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -1,46 +1,18 @@
 .main {
-  display: block;
-  padding-top: var(--bootstrap-padding);
-  padding-bottom: var(--bootstrap-padding);
-  margin-bottom: 0;
-
-  & > div {
-    border: 0;
-    position: relative;
-    display: flex;
-    flex: 1 1 0%;
-    flex-direction: column;
-    min-width: 0;
-
-    @media only screen and (max-width: 767px) {
-      height: auto;
-    }
-
-    & > div {
-      display: flex;
-      position: relative;
-      height: fit-content;
-      padding: 1em;
-      border: 0;
-      border-radius: .5em;
-      background-color: var(--background-light);
-      box-shadow: 0 7px 5px 0 rgba(0, 0, 0, 0.2), 0 10px 1em 0 rgba(0,0,0,.08), 0 4px 0px 0 #33405220;
-
-      @media only screen and (max-width: 767px) {
-        flex-direction: column;
-      }
-    }
-  }
-}
-
-
-
-
-.content, .sidebar {
+  display: grid;
+  grid-template-columns: 1fr 25%;
+  grid-template-rows: auto auto 1fr;
+  overflow-y: auto;
+  gap: 1em;
+  padding: 1em;
+  margin-top: var(--bootstrap-padding);
+  margin-bottom: var(--bootstrap-padding);
+  background-color: var(--background-light);
+  border-radius: 0.5em;
+  box-shadow: 0 7px 5px 0 rgba(0, 0, 0, 0.2), 0 10px 1em 0 rgba(0, 0, 0, 0.08),
+    0 4px 0px 0 #33405220;
   // Since sigma canvas requires a calculated height to fill available space on
   // the page we have to subtract all heights that are not canvas:
-  //   1em padding-top on .main > div > div
-  //   1em padding-bottom on .main > div > div
   //   1 var(--bootstrap-padding) padding-top on .main
   //   1 var(--bootstrap-padding) padding-bottom on .main
   //   1 var(--bootstrap-padding) padding-top on .sticky-inner-wrapper > span
@@ -48,47 +20,73 @@
   //   2em min-height on .PlayDetailsNav_main
   //
   // And leave at least one pixel to trigger the sticky header – that's the "-1px".
-  height: calc(100vh - (8em - 1px) - (var(--bootstrap-padding) * 3));
+  height: calc(100vh - (6em - 1px) - (var(--bootstrap-padding) * 3));
+  
   @media only screen and (max-width: 1440px) {
-    height: calc(100vh - (8em - 3px) - (var(--bootstrap-padding) * 3));
+    height: calc(100vh - (6em - 3px) - (var(--bootstrap-padding) * 3));
   }
-  @media only screen and (max-width: 767px) {
-    width: 100%;
+
+  .content {
+    display: flex;
+    overflow-y: auto;
+    grid-row: span 3 / auto;
+
+    @media only screen and (max-width: 767px) {
+      grid-row: 2 / 3;
+      min-height: calc(100vh - 15em);
+      min-width: 100%;
+      height: auto;
+    }
   }
-}
 
-.content {
-  width: calc(100% * 3 / 4);
-  display: flex;
-  position: relative;
-  margin-right: 1em;
-  overflow: hidden;
+  .description,
+  .metrics,
+  .cast {
+    align-self: start;
+    background: var(--background);
+    padding: var(--bootstrap-padding);
+    border-radius: 0.5rem;
+    font-size: 0.85em;
+    overflow-y: auto;
+    max-height: 100%;
+
+    h4 {
+      font-weight: 400;
+      font-size: 1.3em;
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .cast {
+    grid-row: span 2;
+  }
+
+  .description {
+    @media only screen and (max-width: 767px) {
+      grid-column: 1;
+      grid-row: 1 / 2;
+    }
+  }
+
+  .metrics {
+    @media only screen and (max-width: 767px) {
+      grid-column: 1;
+      grid-row: 3 / 4;
+    }
+  }
+
+  .cast {
+    @media only screen and (max-width: 767px) {
+      grid-column: 1;
+      grid-row: 4 / 5;
+    }
+  }
 
   @media only screen and (max-width: 767px) {
-    min-height: calc(100vh - 4.2em);
-    overflow-y: hidden;
-    width: auto;
+    grid-template-columns: 1fr;
     height: auto;
-    margin-right: 0;
-  }
-}
-
-.sidebar {
-  overflow-y: auto;
-  width: calc(100% / 4);
-
-  @media only screen and (max-width: 767px) {
-    margin-top: 2em;
-    width: auto;
-    height: auto;
-  }
-}
-
-.description {
-  background: var(--background);
-  padding: var(--bootstrap-padding);
-  margin-bottom: var(--bootstrap-padding);
-  p:last-child {
-    margin-bottom: 0;
   }
 }

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -66,6 +66,7 @@ const PlayMetrics = ({play}) => {
 
   return (
     <div className={cx('main')}>
+      <h4>Basic network properties</h4>
       Segments: {play.segments.length}
       <br/>
       All-in at segment {play.allInSegment + ' '}

--- a/src/components/PlayMetrics.js
+++ b/src/components/PlayMetrics.js
@@ -1,10 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames/bind';
-import style from './PlayMetrics.module.scss';
 import api from '../api';
-
-const cx = classnames.bind(style);
 
 function round (n) {
   return Math.round(n * 100) / 100;
@@ -65,8 +61,8 @@ const PlayMetrics = ({play}) => {
   const allInPercentage = Math.round(play.allInIndex * 100);
 
   return (
-    <div className={cx('main')}>
-      <h4>Basic network properties</h4>
+    <div>
+      <h4>Network properties</h4>
       Segments: {play.segments.length}
       <br/>
       All-in at segment {play.allInSegment + ' '}

--- a/src/components/PlayMetrics.module.scss
+++ b/src/components/PlayMetrics.module.scss
@@ -1,7 +1,0 @@
-.main {
-  font-size: 0.85rem;
-  background: var(--background);
-  padding: 0.5rem;
-  border-radius: 0.25rem;
-  width: 100%;
-}

--- a/src/components/PlayMetrics.module.scss
+++ b/src/components/PlayMetrics.module.scss
@@ -1,13 +1,7 @@
 .main {
-  font-size: .85rem;
+  font-size: 0.85rem;
   background: var(--background);
-  padding: .5rem;
-  border-radius: .25rem;
-  opacity: .8;
-  bottom: 0;
-  position: absolute;
-
-  @media only screen and (max-width: 767px) {
-    width: 100%;
-  }
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  width: 100%;
 }

--- a/src/components/SpeechDistribution.js
+++ b/src/components/SpeechDistribution.js
@@ -11,38 +11,44 @@ export const SpeechDistributionNav = ({type, onChange}) => {
   const handleChange = e => onChange(e.target.value);
 
   return (
-    <Form>
-      <FormGroup check>
-        <Label check>
-          <Input
-            type="radio"
-            value="sapogov"
-            checked={type === 'sapogov'}
-            onChange={handleChange}
-          /> Sapogov
-        </Label>
-      </FormGroup>
-      <FormGroup check>
-        <Label check>
-          <Input
-            type="radio"
-            value="yarkho"
-            checked={type === 'yarkho'}
-            onChange={handleChange}
-          /> Yarkho
-        </Label>
-      </FormGroup>
-      <FormGroup check>
-        <Label check>
-          <Input
-            type="radio"
-            value="trilckefischer"
-            checked={type === 'trilckefischer'}
-            onChange={handleChange}
-          /> Trilcke/Fischer et al.
-        </Label>
-      </FormGroup>
-    </Form>
+    <div>
+      <p>This tab shows different ways of visualising speech distribution.</p>
+      <Form>
+        <FormGroup check>
+          <Label check>
+            <Input
+              type="radio"
+              value="sapogov"
+              checked={type === 'sapogov'}
+              onChange={handleChange}
+            />{' '}
+            Sapogov{' '}<a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">1974</a>
+          </Label>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input
+              type="radio"
+              value="yarkho"
+              checked={type === 'yarkho'}
+              onChange={handleChange}
+            />{' '}
+            Yarkho{' '}<a href="http://rvb.ru/philologica/04/04iarxo.htm">1997 (ru)</a>{', '}<a href="https://doi.org/10.1515/jlt-2019-0002">2019 (en)</a>
+          </Label>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input
+              type="radio"
+              value="trilckefischer"
+              checked={type === 'trilckefischer'}
+              onChange={handleChange}
+            />{' '}
+            Trilcke/Fischer et al.{' '}<a href="https://dh2017.adho.org/abstracts/071/071.pdf">2017</a>
+          </Label>
+        </FormGroup>
+      </Form>
+    </div>
   );
 };
 

--- a/src/components/SpeechDistribution/Sapogov.js
+++ b/src/components/SpeechDistribution/Sapogov.js
@@ -101,12 +101,6 @@ class Sapogov extends Component {
     return (
       <>
         <Line data={data} options={options}/>
-        <p>
-          {'Cf. '}
-          <a href="https://www.zotero.org/groups/940512/dlina/items/itemKey/BU7ZB3LY">
-            Sapogov 1974
-          </a>
-        </p>
       </>
     );
   }

--- a/src/components/SpeechDistribution/TrilckeFischer.js
+++ b/src/components/SpeechDistribution/TrilckeFischer.js
@@ -52,7 +52,7 @@ const TrilckeFischer = ({segments}) => {
 
   return (
     <>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={453}>
         <LineChart
           data={data}
         >
@@ -104,13 +104,6 @@ const TrilckeFischer = ({segments}) => {
           />
         </LineChart>
       </ResponsiveContainer>
-
-      <p>
-        {'Cf. '}
-        <a href="https://dh2017.adho.org/abstracts/071/071.pdf">
-          Trilcke/Fischer et al. 2017
-        </a>
-      </p>
     </>
   );
 };

--- a/src/components/SpeechDistribution/Yarkho.js
+++ b/src/components/SpeechDistribution/Yarkho.js
@@ -146,16 +146,6 @@ class Yarkho extends Component {
     return (
       <>
         <Line data={data} options={options}/>
-        <p>
-          {'Cf. '}
-          <a href="http://rvb.ru/philologica/04/04iarxo.htm">
-            Yarkho 1997 (ru)
-          </a>
-          {', '}
-          <a href="https://doi.org/10.1515/jlt-2019-0002">
-            Yarkho 2019 (en)
-          </a>
-        </p>
       </>
     );
   }


### PR DESCRIPTION
This pull request makes use of CSS grid for displaying play tab contents in a more responsive, flexible way. 
Depending on the screen size, informational widgets will appear in specified order and places (grid areas).