### PR TITLE
Add acts/scenes list to full text tab

### DIFF
--- a/src/components/Play.js
+++ b/src/components/Play.js
@@ -15,6 +15,7 @@ import RelationsGraph from './RelationsGraph';
 import SpeechDistribution, {SpeechDistributionNav} from './SpeechDistribution';
 import TEIPanel from './TEIPanel';
 import PlayMetrics from './PlayMetrics';
+import Segments from './Segments';
 
 import './Play.scss';
 
@@ -111,6 +112,7 @@ const PlayInfo = ({corpusId, playId}) => {
   let description = null;
   let cast = null;
   let metrics = null;
+  let segments = null;
 
   if (tab === 'speech') {
     tabContent = (
@@ -140,6 +142,7 @@ const PlayInfo = ({corpusId, playId}) => {
     description = (
       <SourceInfo source={play.source} original={play.originalSource} />
     );
+    segments = <Segments play={play} />;
   } else if (tab === 'relations') {
     tabContent = <RelationsGraph {...{play, nodeColor, edgeColor}} />;
     cast = castList;
@@ -181,7 +184,12 @@ const PlayInfo = ({corpusId, playId}) => {
         <PlayDetailsNav items={items} current={tab} />
       </PlayDetailsHeader>
       <Container fluid>
-        <PlayDetailsTab cast={cast} description={description} metrics={metrics}>
+        <PlayDetailsTab
+          cast={cast}
+          description={description}
+          metrics={metrics}
+          segments={segments}
+        >
           {tabContent}
         </PlayDetailsTab>
       </Container>

--- a/src/components/PlayDetailsTab.js
+++ b/src/components/PlayDetailsTab.js
@@ -5,13 +5,16 @@ import style from './PlayDetailsTab.module.scss';
 
 const cx = classnames.bind(style);
 
-const PlayDetailsTab = ({children, description, cast, metrics}) => {
+const PlayDetailsTab = ({children, description, cast, metrics, segments}) => {
   return (
     <div className={cx('main')}>
       <div className={cx('content')}>{children}</div>
       <div className={cx('description')}>{description}</div>
       {metrics && <div className={cx('metrics')}>{metrics}</div>}
       {cast && <div className={cx('cast', 'dracor-scrollbar')}>{cast}</div>}
+      {segments && (
+        <div className={cx('segments', 'dracor-scrollbar')}>{segments}</div>
+      )}
     </div>
   );
 };

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -32,7 +32,7 @@
     grid-row: span 3 / auto;
 
     @media only screen and (max-width: 767px) {
-      grid-row: 2 / 3;
+      grid-row: 3 / 4;
       min-height: calc(100vh - 15em);
       min-width: 100%;
       height: auto;
@@ -61,7 +61,7 @@
     }
   }
 
-  .cast {
+  .cast, .segments {
     grid-row: span 2;
   }
 
@@ -75,7 +75,7 @@
   .metrics {
     @media only screen and (max-width: 767px) {
       grid-column: 1;
-      grid-row: 3 / 4;
+      grid-row: 2 / 3;
     }
   }
 
@@ -83,6 +83,13 @@
     @media only screen and (max-width: 767px) {
       grid-column: 1;
       grid-row: 4 / 5;
+    }
+  }
+
+  .segments {
+    @media only screen and (max-width: 767px) {
+      grid-column: 1;
+      grid-row: 2 / 3;
     }
   }
 

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -41,6 +41,7 @@
 
   .description,
   .metrics,
+  .segments,
   .cast {
     align-self: start;
     background: var(--background);

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -65,6 +65,10 @@
     grid-row: span 2;
   }
 
+  .segments ol li ol {
+    margin-bottom: 1em;
+  }
+
   .description {
     @media only screen and (max-width: 767px) {
       grid-column: 1;

--- a/src/components/PlayDetailsTab.module.scss
+++ b/src/components/PlayDetailsTab.module.scss
@@ -65,10 +65,6 @@
     grid-row: span 2;
   }
 
-  .segments ol li ol {
-    margin-bottom: 1em;
-  }
-
   .description {
     @media only screen and (max-width: 767px) {
       grid-column: 1;

--- a/src/components/Segments.module.scss
+++ b/src/components/Segments.module.scss
@@ -1,0 +1,23 @@
+.main {
+  ol {
+    list-style-type: none;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  ol ol {
+    padding-left: 1rem;
+  }
+
+  li {
+    margin-bottom: 0.2em;
+    // segment title
+    & > p {
+      margin-bottom: 0;
+    }
+    // segment speakers
+    & > i {
+      font-size: 80%;
+    }
+  }
+}

--- a/src/components/Segments.module.scss
+++ b/src/components/Segments.module.scss
@@ -7,6 +7,7 @@
 
   ol ol {
     padding-left: 1rem;
+    margin-bottom: 1em;
   }
 
   li {

--- a/src/components/Segments.tsx
+++ b/src/components/Segments.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import classnames from 'classnames/bind';
+import {Play, Segment} from '../types';
+import style from './Segments.module.scss';
+
+const cx = classnames.bind(style);
+
+interface TreeSegment {
+  title: string;
+  segments: TreeSegment[];
+  speakers?: string[];
+}
+
+function branch(level: TreeSegment[], title: string, speakers?: string[]) {
+  const seg = level.find((s) => s.title === title);
+  if (seg) {
+    return seg.segments;
+  }
+  const newSeg: TreeSegment = {title, segments: []};
+  if (speakers) {
+    newSeg.speakers = speakers;
+  }
+  level.push(newSeg);
+  return newSeg.segments;
+}
+
+function buildTree(segments: Segment[], map: CastMap) {
+  console.log(segments);
+  const tree: TreeSegment[] = segments.reduce((acc: TreeSegment[], segment) => {
+    const title = segment.title || `[#${segment.number}]`;
+    const parts = title.split(' | ');
+    let level: TreeSegment[] = acc;
+    parts.forEach((p, i) => {
+      if (i === parts.length - 1) {
+        const {speakers = []} = segment;
+        level = branch(
+          level,
+          p,
+          speakers.map((s) => map[s])
+        );
+      } else {
+        level = branch(level, p);
+      }
+    });
+    return acc;
+  }, []);
+  return tree;
+}
+
+interface CastMap {
+  [id: string]: string;
+}
+
+interface Props {
+  play: Play;
+}
+
+const Segments = ({play: {cast, segments}}: Props) => {
+  const castMap: CastMap = cast.reduce((map: CastMap, member) => {
+    map[member.id] = member.name;
+    return map;
+  }, {});
+
+  const tree = buildTree(segments, castMap);
+
+  return (
+    <div className={cx('main')}>
+      <ol>
+        {tree.map((segment) => (
+          <Seg key={segment.title} seg={segment} />
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+const Seg = ({seg}: {seg: TreeSegment}) => (
+  <li>
+    <p>{seg.title}</p>
+    {seg.segments.length > 0 && (
+      <ol>
+        {seg.segments.map((s) => (
+          <Seg key={s.title} seg={s} />
+        ))}
+      </ol>
+    )}
+    {seg.speakers && <i>{seg.speakers.join(', ')}</i>}
+  </li>
+);
+
+export default Segments;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,3 +4,65 @@ export interface ApiInfo {
   status: string;
   existdb: string;
 }
+
+export interface Ref {
+  ref: string;
+  type: string;
+}
+
+export interface Author {
+  name: string;
+  fullname?: string;
+  shortname?: string;
+  refs?: Ref[];
+  // DEPRECATED
+  key?: string;
+}
+
+export interface CastMember {
+  id: string;
+  name: string;
+  sex?: 'FEMALE' | 'MALE' | 'UNKNOWN';
+  isGroup?: boolean;
+  wikidataId?: string;
+}
+
+export interface Relation {
+  source: string;
+  target: string;
+  type: string;
+  directed: boolean;
+}
+
+export interface Segment {
+  number: number;
+  title?: string;
+  type?: string; // 'scene'
+  speakers: string[];
+}
+
+export interface Play {
+  id: string;
+  name: string;
+  corpus: string;
+  title: string;
+  subtitle?: string;
+  authors: Author[];
+  genre: string;
+  libretto: boolean;
+  originalSource: string;
+  relations?: Relation[];
+  cast: CastMember[];
+  segments: Segment[];
+  source?: {
+    name: string;
+    url: string;
+  };
+  wikidataId?: string;
+  yearNormalized: number;
+  yearPremiered: string;
+  yearPrinted: string;
+  yearWritten: string;
+  allInIndex?: number;
+  allInSegment?: number;
+}


### PR DESCRIPTION
This PR implements a `Segments` component that lists acts and scenes of a play and adds this list to the full text tab of the play details page.

It builds upon the typescript fixes of #187.

NB: In mobile view the list is still rendered after the text. This should be adjusted in the grid setup.

partially solves #76