### PR TITLE
Add corpus metadata download options

### DIFF
--- a/src/components/CorpusIndex.js
+++ b/src/components/CorpusIndex.js
@@ -200,8 +200,8 @@ const CorpusIndex = ({data}) => {
     },
   ];
 
-  const jsonUrl = `${apiUrl}/corpus/#/metadata/`;
-  const csvUrl = `${apiUrl}/corpus/#/metadata/csv`;
+  const jsonUrl = `${apiUrl}/corpora/${data.name}/metadata`;
+  const csvUrl = `${apiUrl}/corpora/${data.name}/metadata/csv`;
 
   return (
     <div>
@@ -242,7 +242,7 @@ const CorpusIndex = ({data}) => {
                       href={jsonUrl}
                       target="_blank"
                       rel="noreferrer noopener"
-                      download="#.json"
+                      download={`${data.name}dracor-metadata.json`}
                     >
                       <img src={svgJSON} alt="JSON" />
                     </a>
@@ -251,7 +251,7 @@ const CorpusIndex = ({data}) => {
                       href={csvUrl}
                       target="_blank"
                       rel="noreferrer noopener"
-                      download="#.csv"
+                      download={`${data.name}dracor-metadata.csv`}
                     >
                       <img src={svgCSV} alt="" />
                     </a>

--- a/src/components/CorpusIndex.js
+++ b/src/components/CorpusIndex.js
@@ -13,9 +13,6 @@ import './CorpusIndex.scss';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faInfoCircle} from '@fortawesome/free-solid-svg-icons';
 
-import svgJSON from '../images/json.svg';
-import svgCSV from '../images/csv.svg';
-
 const {SearchBar} = Search;
 
 function formatAuthor(authorNames, d) {
@@ -236,7 +233,7 @@ const CorpusIndex = ({data}) => {
                   )}
                   <p>
                     Download a comprehensive table with metadata on all plays in
-                    the corpus:
+                    the corpus:{' '}
                     <a
                       className="download-corpus"
                       href={jsonUrl}
@@ -244,8 +241,8 @@ const CorpusIndex = ({data}) => {
                       rel="noreferrer noopener"
                       download={`${data.name}dracor-metadata.json`}
                     >
-                      <img src={svgJSON} alt="JSON" />
-                    </a>
+                      JSON
+                    </a>{' '}
                     <a
                       className="download-corpus"
                       href={csvUrl}
@@ -253,7 +250,7 @@ const CorpusIndex = ({data}) => {
                       rel="noreferrer noopener"
                       download={`${data.name}dracor-metadata.csv`}
                     >
-                      <img src={svgCSV} alt="" />
+                      CSV
                     </a>
                   </p>
                 </div>

--- a/src/components/CorpusIndex.js
+++ b/src/components/CorpusIndex.js
@@ -13,6 +13,9 @@ import './CorpusIndex.scss';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faInfoCircle} from '@fortawesome/free-solid-svg-icons';
 
+import svgJSON from '../images/json.svg';
+import svgCSV from '../images/csv.svg';
+
 const {SearchBar} = Search;
 
 function formatAuthor(authorNames, d) {
@@ -197,6 +200,9 @@ const CorpusIndex = ({data}) => {
     },
   ];
 
+  const jsonUrl = `${apiUrl}/corpus/#/metadata/`;
+  const csvUrl = `${apiUrl}/corpus/#/metadata/csv`;
+
   return (
     <div>
       <Helmet titleTemplate="%s - DraCor">
@@ -228,6 +234,28 @@ const CorpusIndex = ({data}) => {
                       </a>
                     </p>
                   )}
+                  <p>
+                    Download a comprehensive table with metadata on all plays in
+                    the corpus:
+                    <a
+                      className="download-corpus"
+                      href={jsonUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      download="#.json"
+                    >
+                      <img src={svgJSON} alt="JSON" />
+                    </a>
+                    <a
+                      className="download-corpus"
+                      href={csvUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      download="#.csv"
+                    >
+                      <img src={svgCSV} alt="" />
+                    </a>
+                  </p>
                 </div>
               )}
               <SearchBar {...props.searchProps} />

--- a/src/components/CorpusIndex.scss
+++ b/src/components/CorpusIndex.scss
@@ -11,3 +11,18 @@ table.table.corpus {
     margin-right: 4px;
   }
 }
+
+.download-corpus {
+  display: table-cell;
+
+  img {
+    height: 4em;
+    margin: .5em .5em .5em 0;
+    transition: opacity 0.3s ease-in-out;
+
+    &:hover,
+    &:focus {
+      opacity: 0.85;
+    }
+  }
+}

--- a/src/components/CorpusIndex.scss
+++ b/src/components/CorpusIndex.scss
@@ -13,16 +13,18 @@ table.table.corpus {
 }
 
 .download-corpus {
-  display: table-cell;
+  color: var(--background-light);
+  border-radius: 0.5em;
+  font-size: .85em;
+  background-color: var(--main);
+  padding: 0.3em 0.6em;
+  box-shadow: 0 5px 5px 0 var(--shadow), 0 4px 0px 0 var(--main-shadow);
+  white-space: nowrap;
+  transition: all .3s ease-in-out;
+}
 
-  img {
-    height: 4em;
-    margin: .5em .5em .5em 0;
-    transition: opacity 0.3s ease-in-out;
-
-    &:hover,
-    &:focus {
-      opacity: 0.85;
-    }
-  }
+.download-corpus:hover {
+  text-decoration: none;
+  color: var(--secondary-accent);
+  box-shadow: 0 3px 0px 0 #33405220;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -447,6 +447,7 @@ table.table.corpus th:focus {
   line-height: 3.5em;
   box-shadow: 0 5px 5px 0 var(--shadow), 0 4px 0px 0 var(--main-shadow);
   white-space: nowrap;
+  transition: all .3s ease-in-out;
 }
 
 .download-button:hover {


### PR DESCRIPTION
This PR adds direct download options for corpus metadata in the index.

Download URLs require some missing constants '#'. 