### PR TITLE
Add plain text option to tools tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^4.5.3",
     "chart.js": "^2.9.4",
     "classnames": "^2.2.6",
+    "compare-versions": "^6.1.1",
     "globals": "^15.14.0",
     "react": "^18.3.1",
     "react-bootstrap-table-next": "^4.0.3",

--- a/src/components/ToolsTab.tsx
+++ b/src/components/ToolsTab.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default function ToolsTab({corpusId, playId}: Props) {
   const [textType, setTextType] = useState<
-    'tei' | 'spoken-text' | 'stage-directions'
+    'tei' | 'txt' | 'spoken-text' | 'stage-directions'
   >('tei');
   const apiBase = new URL(apiUrl, window.location.href);
 
@@ -41,6 +41,9 @@ export default function ToolsTab({corpusId, playId}: Props) {
             <label onClick={() => setTextType('tei')}>
               <input type="radio" checked={textType === 'tei'} /> Full text
               (TEI-encoded)
+            </label>{' '}
+            <label onClick={() => setTextType('txt')}>
+              <input type="radio" checked={textType === 'txt'} /> Plain text
             </label>{' '}
             <label onClick={() => setTextType('spoken-text')}>
               <input type="radio" checked={textType === 'spoken-text'} /> Spoken

--- a/src/components/ToolsTab.tsx
+++ b/src/components/ToolsTab.tsx
@@ -1,5 +1,7 @@
-import {useState} from 'react';
+import {useContext, useState} from 'react';
 import classnames from 'classnames/bind';
+import {compareVersions} from 'compare-versions';
+import {DracorContext} from '../context';
 import style from './ToolsTab.module.scss';
 import {apiUrl} from '../config';
 
@@ -11,6 +13,7 @@ interface Props {
 }
 
 export default function ToolsTab({corpusId, playId}: Props) {
+  const {apiInfo} = useContext(DracorContext);
   const [textType, setTextType] = useState<
     'tei' | 'txt' | 'spoken-text' | 'stage-directions'
   >('tei');
@@ -42,9 +45,12 @@ export default function ToolsTab({corpusId, playId}: Props) {
               <input type="radio" checked={textType === 'tei'} /> Full text
               (TEI-encoded)
             </label>{' '}
-            <label onClick={() => setTextType('txt')}>
-              <input type="radio" checked={textType === 'txt'} /> Plain text
-            </label>{' '}
+            {apiInfo &&
+              compareVersions(apiInfo.version, '1.1.0-beta.7') >= 0 && (
+                <label onClick={() => setTextType('txt')}>
+                  <input type="radio" checked={textType === 'txt'} /> Plain text{' '}
+                </label>
+              )}
             <label onClick={() => setTextType('spoken-text')}>
               <input type="radio" checked={textType === 'spoken-text'} /> Spoken
               text

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,6 @@
 import {createContext} from 'react';
+import {DracorContext as ContextType} from './types';
 
-export const DracorContext = createContext({corpora: [], apiInfo: {}});
+export const DracorContext = createContext<ContextType>({
+  corpora: [],
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,11 @@ export interface ApiInfo {
   existdb: string;
 }
 
+export interface DracorContext {
+  corpora: never[];
+  apiInfo?: ApiInfo;
+}
+
 export interface Ref {
   ref: string;
   type: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,6 +2757,11 @@ commander@^6.1.0:
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 component-emitter@^1.3.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"


### PR DESCRIPTION
This enables sending the full plain text of the play to the external tool (if the API version ist >=1.1.0-beta.7).