### PR TITLE
Render notBefore/notAfter as inclusive bounds

### DIFF
--- a/src/components/Years.tsx
+++ b/src/components/Years.tsx
@@ -31,16 +31,19 @@ export function formatYear(yearString: string) {
     return `${formatEra(years[0])}-${formatEra(years[1], 1000)}`;
   }
 
-  // not before
-  if (yearString.match('^>-?[0-9]{4}')) {
-    const year = yearString.slice(1);
-    return `after ${formatEra(year, 1000)}`;
+  // not before — the API currently emits `>YYYY` for TEI `@notBefore`, which
+  // is semantically inclusive (≥). Accept `≥`/`>=` too so this keeps working
+  // once the API is corrected (see
+  // https://github.com/dracor-org/dracor-frontend/issues/400).
+  if (yearString.match('^(>=?|≥)-?[0-9]{4}')) {
+    const year = yearString.replace(/^(>=?|≥)/, '');
+    return `not before ${formatEra(year, 1000)}`;
   }
 
-  // not after
-  if (yearString.match('^<-?[0-9]{4}')) {
-    const year = yearString.slice(1);
-    return `before ${formatEra(year, 1000)}`;
+  // not after — same story for `<YYYY` (TEI `@notAfter`, inclusive ≤).
+  if (yearString.match('^(<=?|≤)-?[0-9]{4}')) {
+    const year = yearString.replace(/^(<=?|≤)/, '');
+    return `not after ${formatEra(year, 1000)}`;
   }
 
   // single year


### PR DESCRIPTION
The TEI `@notBefore`/`@notAfter` attributes are inclusive (≥/≤), but the frontend rendered `>YYYY`/`<YYYY` as "after YYYY"/"before YYYY", implying strict inequality. Switch the wording to "not before YYYY"/"not after YYYY" so the display matches the source semantics, and accept `≥`/`>=` and `≤`/`<=` prefixes as forward-compat for when the API drops the misleading strict-comparison notation.

Closes #400